### PR TITLE
Groups office referrals in student profile view

### DIFF
--- a/app/assets/stylesheets/student.scss
+++ b/app/assets/stylesheets/student.scss
@@ -37,7 +37,7 @@
 
 .referral {
   margin-top: 20px;
-
+  
   .referral-date{
     margin-top: 5px;
   }

--- a/app/views/students/_school_year_box.html.erb
+++ b/app/views/students/_school_year_box.html.erb
@@ -123,14 +123,14 @@
       <div class="section">
         <% if events[:discipline_incidents].present? %>
           <h2>Office referrals</h2>
-          <div class="referral">
             <% events[:discipline_incidents].each do |d| %>
-              <p><strong>Code:</strong>  <%= d.incident_code %></p>
-              <p><strong>Description:</strong>  <%= d.incident_description %></p>
-              <p><strong>Location:</strong>  <%= d.incident_location %></p>
-              <p><strong>Date:</strong>  <%= d.event_date.strftime("%B %e, %Y") %></p>
+              <div class="referral">
+                <p><strong>Code:</strong>  <%= d.incident_code %></p>
+                <p><strong>Description:</strong>  <%= d.incident_description %></p>
+                <p><strong>Location:</strong>  <%= d.incident_location %></p>
+                <p><strong>Date:</strong>  <%= d.event_date.strftime("%B %e, %Y") %></p>
+              </div>
             <% end %>
-          </div>
         <% else %>
           <h2>No office referrals</h2>
         <% end %>


### PR DESCRIPTION
makes referrals more readable.  This:
![screen shot 2015-06-10 at 4 51 25 pm](https://cloud.githubusercontent.com/assets/4649503/8096941/756f2a5a-0f91-11e5-86e8-e0a2d7870ed0.png)

instead of this:
![screen shot 2015-06-10 at 4 51 37 pm](https://cloud.githubusercontent.com/assets/4649503/8096943/7df97b76-0f91-11e5-86d5-8d6e57595b8e.png)

