### PR TITLE
Add ERD gem for easy diagram creation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -49,6 +49,9 @@ group :development, :test do
   gem 'probability'
   gem 'rubystats'
 
+  # to auto-generate ERD and better understand the data structure
+  gem 'rails-erd'
+
 end
 
 # Auth

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -36,6 +36,7 @@ GEM
       rack (>= 1.0.0)
       rack-test (>= 0.5.4)
       xpath (~> 2.0)
+    choice (0.2.0)
     climate_control (0.0.3)
       activesupport (>= 3.0)
     cocaine (0.5.7)
@@ -120,6 +121,11 @@ GEM
       bundler (>= 1.3.0, < 2.0)
       railties (= 4.1.4)
       sprockets-rails (~> 2.0)
+    rails-erd (1.4.0)
+      activerecord (>= 3.2)
+      activesupport (>= 3.2)
+      choice (~> 0.2.0)
+      ruby-graphviz (~> 1.2)
     rails_12factor (0.0.3)
       rails_serve_static_assets
       rails_stdout_logging
@@ -155,6 +161,7 @@ GEM
       rspec-mocks (~> 3.2.0)
       rspec-support (~> 3.2.0)
     rspec-support (3.2.2)
+    ruby-graphviz (1.2.2)
     rubystats (0.2.3)
     rubyzip (1.1.7)
     sass (3.2.19)
@@ -229,6 +236,7 @@ DEPENDENCIES
   puma
   rack-test
   rails (= 4.1.4)
+  rails-erd
   rails_12factor
   roo
   rspec-rails (~> 3.0)


### PR DESCRIPTION
I found this helpful as a newcomer to the project.  A [simple command](http://voormedia.github.io/rails-erd/install.html#generate) generates a diagram of model relationships.  

![erd](https://cloud.githubusercontent.com/assets/4649503/8243506/5fbdaefc-15cc-11e5-8a1d-a7869625f1a8.png)
