### PR TITLE
Fix STAR results in profile view

### DIFF
--- a/app/models/school_year.rb
+++ b/app/models/school_year.rb
@@ -18,7 +18,7 @@ class SchoolYear < ActiveRecord::Base
       attendance_events: attendance_events.find_by_student(student).summarize,
       discipline_incidents: discipline_incidents.find_by_student(student),
       mcas_result: mcas_results.find_by_student(student).last,
-      star_results: star_results.find_by_student(student),
+      star_results: star_results.find_by_student(student).order(date_taken: :desc)
     }
   end
 end

--- a/app/views/students/_school_year_box.html.erb
+++ b/app/views/students/_school_year_box.html.erb
@@ -61,18 +61,18 @@
             <div class="values">
               <h3 class="assesment-type">Reading</h3>
               <div class="values">
-                <h3><%= s.reading_percentile_rank %></h3>
+                <h3><%= StarResultPresenter.new(s).reading_percentile_rank %></h3>
                 <h4>Percentile</h4>
               </div>
               <div class="values">
-                <h3><%= s.instructional_reading_level %></h3>
+                <h3><%= StarResultPresenter.new(s).instructional_reading_level %></h3>
                 <h4>IRL</h4>
               </div>
             </div>
             <div class="values">
               <h3 class="assesment-type">Math</h3>
               <div class="values">
-                <h3><%= s.math_percentile_rank %></h3>
+                <h3><%= StarResultPresenter.new(s).math_percentile_rank %></h3>
                 <h4>Percentile</h4>
               </div>
             </div>


### PR DESCRIPTION
## What's new?

* STAR results sorted by descending date
* Em-dashes that capture missing values like so:

![star results box](https://cloud.githubusercontent.com/assets/3209501/8528390/c1a74b9c-23e0-11e5-9143-498a1a159fa8.png)
