### PR TITLE
Added the roster_url to the controller and mapped it to the path of t…

### DIFF
--- a/app/controllers/students_controller.rb
+++ b/app/controllers/students_controller.rb
@@ -10,6 +10,7 @@ class StudentsController < ApplicationController
     @discipline_incidents = @student.discipline_incidents.sort_by_school_year
     @mcas_results = @student.mcas_results.order(:date_taken)
     @star_results = @student.star_results.order(:date_taken)
+    @roster_url = homeroom_students_path(@student.homeroom)
   end
 
   def index

--- a/app/views/students/show.html.erb
+++ b/app/views/students/show.html.erb
@@ -1,6 +1,6 @@
 	<div id="controls">
 		<div id="roster-back">
-			<%= link_to "< Back to Roster", roster_url %>
+			<%= link_to "< Back to Roster", @roster_url %>
 		</div>
 	</div>
 

--- a/spec/factories/students.rb
+++ b/spec/factories/students.rb
@@ -6,6 +6,7 @@ FactoryGirl.define do
 
   factory :student do
       state_id
+      association :homeroom
     factory :student_who_registered_in_2013_2014 do
       registration_date Date.new(2013, 8, 1)
     end


### PR DESCRIPTION
Set the StudentsController roster_url to the path of the student's homeroom so the roster_url will point to the correct homeroom instead of just the front page.  This fix is referencing https://github.com/codeforamerica/somerville-teacher-tool/issues/159