### PR TITLE
Styles for Risk Level: N/A

### DIFF
--- a/app/assets/stylesheets/overall.scss
+++ b/app/assets/stylesheets/overall.scss
@@ -48,6 +48,10 @@ body {
     background-color: $high;
 }
 
+.na {
+    background-color: $gray;
+}
+
 .blue {
   background-color: $warning-bubble;
 }

--- a/app/models/student_risk_level.rb
+++ b/app/models/student_risk_level.rb
@@ -32,16 +32,11 @@ class StudentRiskLevel < Struct.new :student
   end
 
   def level_abbreviation
-   case level
-    when 0, 1
-      "L"
-    when 2
-      "M"
-    when 3
-      "H"
-    when nil
-      "N/A"
-    end
+    level_in_words == "N/A" ? level_in_words : level_in_words[0]
+  end
+
+  def css_class_name
+    level_in_words.downcase.gsub("/", "")
   end
 
   def explanation

--- a/app/models/student_risk_level.rb
+++ b/app/models/student_risk_level.rb
@@ -31,6 +31,19 @@ class StudentRiskLevel < Struct.new :student
     end
   end
 
+  def level_abbreviation
+   case level
+    when 0, 1
+      "L"
+    when 2
+      "M"
+    when 3
+      "H"
+    when nil
+      "N/A"
+    end
+  end
+
   def explanation
     explanations = []
 

--- a/app/views/students/_student_row.html.erb
+++ b/app/views/students/_student_row.html.erb
@@ -1,8 +1,8 @@
                 <tr class="student-row">
                   <td class="name"><%= link_to presenter.full_name, student_url(presenter.id) %></td>
                   <td class="risk">
-                    <div class="warning-bubble <%= risk.level_in_words.downcase %>">
-                      <%= risk.level_in_words[0] %>
+                    <div class="warning-bubble <%= risk.level_in_words.downcase.gsub("/", "") %>">
+                      <%= risk.level_abbreviation %>
                     </div>
                   </td>
                   <td class="demographics"><%= presenter.home_language %></td>

--- a/app/views/students/_student_row.html.erb
+++ b/app/views/students/_student_row.html.erb
@@ -1,7 +1,7 @@
                 <tr class="student-row">
                   <td class="name"><%= link_to presenter.full_name, student_url(presenter.id) %></td>
                   <td class="risk">
-                    <div class="warning-bubble <%= risk.level_in_words.downcase.gsub("/", "") %>">
+                    <div class="warning-bubble <%= risk.css_class_name %>">
                       <%= risk.level_abbreviation %>
                     </div>
                   </td>

--- a/app/views/students/show.html.erb
+++ b/app/views/students/show.html.erb
@@ -13,7 +13,7 @@
       <h1 id="student-name"><%= @presenter.full_name %></h1>
       <div id="risk-level">
         <p>Risk level:</p>
-        <div id="risk-pill" class="<%= @risk.level_in_words.downcase %>">
+        <div id="risk-pill" class="<%= @risk.css_class_name %>">
           <div class="tooltip-circle">
             <h3><%= @risk.level_in_words %></h3>
           </div>


### PR DESCRIPTION
## What's new?

Some students are missing key pieces of information needed to calculate risk level.

Quick styling for those cases.

__Profile:__

![screen shot 2015-07-26 at 10 52 28 am](https://cloud.githubusercontent.com/assets/3209501/8895148/8fb351d6-3384-11e5-99d5-b318d3c831e0.png)

__Roster:__

![screen shot 2015-07-26 at 10 39 18 am](https://cloud.githubusercontent.com/assets/3209501/8895149/90e6c3da-3384-11e5-9e48-f24abb4cd266.png)
