### PR TITLE
Roster click-through to corresponding profile chart

### DIFF
--- a/app/assets/javascripts/profile.js
+++ b/app/assets/javascripts/profile.js
@@ -50,30 +50,39 @@
     }
   }
 
-  ProfileController.prototype.onChartChange = function profileChartDataChange() {
+  ProfileController.prototype.setChart = function profileSetChart (value) {
     var chart_data = $("#chart-data");
-    var selVal = $("#chart-type").val();
-
-    if (selVal == "attendance") {
+    if (value == "attendance") {
       AttendanceChart.fromChartData(chart_data).render(this);
       return;
-    } else if (selVal == "behavior") {
+    } else if (value == "behavior") {
       BehaviorChart.fromChartData(chart_data).render(this);
       return;
-    } else if (selVal == "mcas-growth") {
+    } else if (value == "mcas-growth") {
       McasGrowthChart.fromChartData(chart_data).render(this);
       return;
-    } else if (selVal == "mcas-scaled") {
+    } else if (value == "mcas-scaled") {
       McasScaledChart.fromChartData(chart_data).render(this);
       return;
-    } else if (selVal == "star") {
+    } else if (value == "star") {
       StarChart.fromChartData(chart_data).render(this);
       return;
     }
   }
 
+  ProfileController.prototype.onChartChange = function profileChartDataChange() {
+    var selVal = $("#chart-type").val();
+    this.setChart(selVal);
+  }
+
   ProfileController.prototype.show = function renderProfileController() {
-    this.onChartChange();
+    var chart_start = $("#chart-start").data('start');
+    var chart_options = ["attendance", "behavior", "mcas-growth", "mcas-scaled", "star"];
+    if (chart_options.indexOf(chart_start) !== -1) {
+      this.setChart(chart_start);
+    } else {
+      this.setChart("mcas-growth");
+    }
 
     // Bind onChartChange to this instance of ProfileController
     var self = this;

--- a/app/assets/javascripts/roster.js
+++ b/app/assets/javascripts/roster.js
@@ -38,8 +38,8 @@ $(function() {
     });
 
     // Turn table rows into links to student profiles
-    $('tbody tr').click(function () {
-      location.href = $(this).find('td a').attr('href');
+    $('tbody td').click(function () {
+      location.href = $(this).attr('href');
     });
 
   }

--- a/app/controllers/students_controller.rb
+++ b/app/controllers/students_controller.rb
@@ -8,6 +8,7 @@ class StudentsController < ApplicationController
   def show
     @student = Student.find(params[:id])
     @presenter = StudentPresenter.new(@student)
+    @chart_start = params[:chart_start] || "mcas-growth"
     @chart_data = StudentProfileChart.new(@student).chart_data
     @risk = StudentRiskLevel.new(student: @student)
 

--- a/app/views/students/_mcas_row_fragment.html.erb
+++ b/app/views/students/_mcas_row_fragment.html.erb
@@ -1,9 +1,13 @@
                     <% if assessment.is_a? MissingAssessment %>
-                      <td class="mcas"><div class="cell-wrapper">—</div></td>
-                      <td class="mcas"><div class="cell-wrapper">—</div></td>
+                      <td class="mcas" href="<%= student_url(student, chart_start: "mcas-scaled") %>">
+                        <div class="cell-wrapper">—</div>
+                      </td>
+                      <td class="mcas" href="<%= student_url(student, chart_start: "mcas-growth") %>">
+                        <div class="cell-wrapper">—</div>
+                      </td>
                     <% else %>
                       <% present(assessment) do |presenter| %>
-                        <td class="mcas">
+                        <td class="mcas" href="<%= student_url(student, chart_start: "mcas-scaled") %>">
                           <div class="cell-wrapper">
                             <% if risk.performance_warning? %>
                               <div class="warning-text"><%= presenter.performance_level %></div>
@@ -12,7 +16,7 @@
                             <% end %>
                           </div>
                         </td>
-                        <td class="mcas">
+                        <td class="mcas" href="<%= student_url(student, chart_start: "mcas-growth") %>">
                           <div class="cell-wrapper">
                             <% if risk.growth_warning? %>
                               <div class="warning-text"><%= presenter.growth_percentile %></div>

--- a/app/views/students/_star_math_row_fragment.html.erb
+++ b/app/views/students/_star_math_row_fragment.html.erb
@@ -1,7 +1,9 @@
                     <% if assessment.is_a? MissingAssessment %>
-                      <td class="star"><div class="cell-wrapper">—</div></td>
+                      <td class="star" href="<%= student_url(student, chart_start: "star") %>">
+                        <div class="cell-wrapper">—</div>
+                      </td>
                     <% else %>
-                        <td class="star">
+                        <td class="star" href="<%= student_url(student, chart_start: "star") %>">
                           <div class="cell-wrapper">
                             <% present(assessment) do |presenter| %>
                               <% if risk.percentile_warning? %>

--- a/app/views/students/_star_reading_row_fragment.html.erb
+++ b/app/views/students/_star_reading_row_fragment.html.erb
@@ -1,9 +1,13 @@
                     <% if assessment.is_a? MissingAssessment %>
-                      <td class="star"><div class="cell-wrapper">—</div></td>
-                      <td class="star"><div class="cell-wrapper">—</div></td>
+                      <td class="star" href="<%= student_url(student, chart_start: "star") %>">
+                        <div class="cell-wrapper">—</div>
+                      </td>
+                      <td class="star" href="<%= student_url(student, chart_start: "star") %>">
+                        <div class="cell-wrapper">—</div>
+                      </td>
                     <% else %>
                       <% present(assessment) do |presenter| %>
-                        <td class="star">
+                        <td class="star" href="<%= student_url(student, chart_start: "star") %>">
                           <div class="cell-wrapper">
                             <% if risk.percentile_warning? %>
                               <div class="warning-text"><%= presenter.percentile_rank %></div>
@@ -12,7 +16,7 @@
                             <% end %>
                           </div>
                         </td>
-                        <td class="star">
+                        <td class="star" href="<%= student_url(student, chart_start: "star") %>">
                           <div class="cell-wrapper">
                             <% if risk.level_warning? %>
                               <div class="warning-text"><%= presenter.instructional_reading_level %></div>

--- a/app/views/students/_student_row.html.erb
+++ b/app/views/students/_student_row.html.erb
@@ -1,66 +1,72 @@
                 <tr class="student-row">
-                  <td class="name">
+                  <td class="name" href="<%= student_url(student) %>">
                     <div class="cell-wrapper">
-                      <%= link_to presenter.full_name, student_url(presenter.id) %>
+                      <%= presenter.full_name %>
                     </div>
                   </td>
-                  <td class="risk">
+                  <td class="risk" href="<%= student_url(student) %>">
                     <div class="warning-bubble <%= risk.css_class_name %>">
                       <%= risk.level_for_roster %>
                     </div>
                   </td>
-                  <td class="program">
+                  <td class="program" href="<%= student_url(student) %>">
                     <%= presenter.program_assigned %>
                   </td>
-                  <td class="sped">
+                  <td class="sped" href="<%= student_url(student) %>">
                     <%= presenter.sped_placement %>
                   </td>
-                  <td class="sped">
+                  <td class="sped" href="<%= student_url(student) %>">
                     <%= presenter.disability %>
                   </td>
-                  <td class="sped">
+                  <td class="sped" href="<%= student_url(student) %>">
                     <%= presenter.sped_level_of_need %>
                   </td>
-                  <td class="sped">
+                  <td class="sped" href="<%= student_url(student) %>">
                     <%= presenter.plan_504 %>
                   </td>
-                  <td class="language">
+                  <td class="language" href="<%= student_url(student) %>">
                     <%= presenter.limited_english_proficiency %>
                   </td>
-                  <td class="language">
+                  <td class="language" href="<%= student_url(student) %>">
                     <%= presenter.home_language %>
                   </td>
-                  <td class="free-reduced">
+                  <td class="free-reduced" href="<%= student_url(student) %>">
                     <%= presenter.free_reduced_lunch %>
                   </td>
 
-                  <%= render "students/star_math_row_fragment", assessment: row_data.latest_star_math, risk: StarRiskLevel.new(row_data.latest_star_math) %>
+                  <%= render "students/star_math_row_fragment", student: student, assessment: row_data.latest_star_math, risk: StarRiskLevel.new(row_data.latest_star_math) %>
 
-                  <%= render "students/star_reading_row_fragment", assessment: row_data.latest_star_reading, risk: StarRiskLevel.new(row_data.latest_star_reading) %>
+                  <%= render "students/star_reading_row_fragment", student: student, assessment: row_data.latest_star_reading, risk: StarRiskLevel.new(row_data.latest_star_reading) %>
 
-                  <%= render "students/mcas_row_fragment", assessment: row_data.latest_mcas_math, risk: McasRiskLevel.new(row_data.latest_mcas_math) %>
+                  <%= render "students/mcas_row_fragment", student: student, assessment: row_data.latest_mcas_math, risk: McasRiskLevel.new(row_data.latest_mcas_math) %>
 
-                  <%= render "students/mcas_row_fragment", assessment: row_data.latest_mcas_ela, risk: McasRiskLevel.new(row_data.latest_mcas_ela) %>
+                  <%= render "students/mcas_row_fragment", student: student, assessment: row_data.latest_mcas_ela, risk: McasRiskLevel.new(row_data.latest_mcas_ela) %>
 
                   <% if row_data.current_events.present? %>
-                    <td class="attendance">
+                    <td class="attendance" href="<%= student_url(student, chart_start: "attendance") %>">
                       <div class="cell-wrapper">
                         <%= row_data.absences_current_year %>
                       </div>
                     </td>
-                    <td class="attendance">
+                    <td class="attendance" href="<%= student_url(student, chart_start: "attendance") %>">
                       <div class="cell-wrapper">
                         <%= row_data.tardies_current_year %>
                       </div>
                     </td>
-                    <td class="discipline">
+                    <td class="discipline" href="<%= student_url(student, chart_start: "behavior") %>">
                       <div class="cell-wrapper">
                         <%= row_data.discipline_current_year %>
                       </div>
                     </td>
                   <% else %>
-                    <td class="attendance"><div class="cell-wrapper">—</div></td>
-                    <td class="attendance"><div class="cell-wrapper">—</div></td>
-                    <td class="discpline"><div class="cell-wrapper">—</div></td>
+                    <td class="attendance" href="<%= student_url(student, chart_start: "attendance") %>">
+                      <div class="cell-wrapper">—</div>
+                    </td>
+                    <td class="attendance" href="<%= student_url(student, chart_start: "attendance") %>">
+                      <div class="cell-wrapper">—</div>
+                    </td>
+                    <td class="discpline" href="<%= student_url(student, chart_start: "behavior") %>">
+                      <div class="cell-wrapper">—</div>
+                    </td>
                   <% end %>
                 </tr>

--- a/app/views/students/show.html.erb
+++ b/app/views/students/show.html.erb
@@ -22,11 +22,21 @@
     <div id="graph-dropdown" class="dropdown">
       <p>Graph:</p>
       <select id="chart-type">
-        <option value="attendance">Attendance</option>
-        <option value="behavior">Behavior</option>
-        <option value="mcas-growth">MCAS Growth</option>
-        <option value="mcas-scaled">MCAS Score</option>
-        <option value="star">STAR</option>
+        <option value="attendance"<% if @chart_start == "attendance" %> selected<% end %>>
+          Attendance
+        </option>
+        <option value="behavior"<% if @chart_start == "behavior" %> selected<% end %>>
+          Behavior
+        </option>
+        <option value="mcas-growth"<% if @chart_start == "mcas-growth" %> selected<% end %>>
+          MCAS Growth
+        </option>
+        <option value="mcas-scaled"<% if @chart_start == "mcas-scaled" %> selected<% end %>>
+          MCAS Score
+        </option>
+        <option value="star"<% if @chart_start == "star" %> selected<% end %>>
+          STAR
+        </option>
       </select>
     </div>
 
@@ -116,3 +126,4 @@
   </script>
 
 <%= tag("div", id: "chart-data", data: @chart_data) %>
+<%= tag("div", id: "chart-start", data: { start: @chart_start }) %>


### PR DESCRIPTION
## What's new?

When you click on a behavior data point on the roster...

![behavior 1](https://cloud.githubusercontent.com/assets/3209501/9117676/a0b4cb0a-3c20-11e5-8a74-9c74c087a39b.png)


... you go to the behavior chart on the profile:

![behavior 2](https://cloud.githubusercontent.com/assets/3209501/9117679/a5a0a3e6-3c20-11e5-8cc3-657e3e65a309.png)

etc.