### PR TITLE
Make SPED part of default roster view

### DIFF
--- a/app/assets/javascripts/roster.js
+++ b/app/assets/javascripts/roster.js
@@ -14,7 +14,7 @@ $(function() {
     $(".attendance").hide();
     $(".discipline").hide();
     $(".language").hide();
-    $(".sped").hide();
+    $(".star").hide();
     $(".program").hide();
     $(".free-reduced").hide();
     $(".access").hide();

--- a/app/views/students/_student_row.html.erb
+++ b/app/views/students/_student_row.html.erb
@@ -13,9 +13,6 @@
                     <%= presenter.program_assigned %>
                   </td>
                   <td class="sped" href="<%= student_url(student) %>">
-                    <%= presenter.sped_placement %>
-                  </td>
-                  <td class="sped" href="<%= student_url(student) %>">
                     <%= presenter.disability %>
                   </td>
                   <td class="sped" href="<%= student_url(student) %>">

--- a/app/views/students/index.html.erb
+++ b/app/views/students/index.html.erb
@@ -20,8 +20,8 @@
         <option value="program">Program</option>
         <option value="language">Language</option>
         <option value="free-reduced">Free/Reduced Lunch</option>
-        <option value="sped">SPED & Disability</option>
-        <option value="star" selected>STAR</option>
+        <option value="sped" selected>SPED & Disability</option>
+        <option value="star">STAR</option>
         <option value="mcas" selected>MCAS</option>
         <option value="access">ACCESS</option>
         <option value="dibels">DIBELS</option>

--- a/app/views/students/index.html.erb
+++ b/app/views/students/index.html.erb
@@ -39,7 +39,7 @@
           <td colspan="1" class="name"></td>
           <td colspan="1" class="risk"></td>
           <td colspan="1" class="program"></td>
-          <td colspan="4" class="sped"><p class="smalltype">SPED & Disability</p></td>
+          <td colspan="3" class="sped"><p class="smalltype">SPED & Disability</p></td>
           <td colspan="2" class="language"><p class="smalltype">Language</p></td>
           <td colspan="1" class="free-reduced"></td>
           <td colspan="3" class="star"><p class="smalltype">STAR</p></td>
@@ -55,7 +55,7 @@
           <td colspan="1" class="name"></td>
           <td colspan="1" class="risk"></td> <!-- Blank column space for nested labels -->
           <td colspan="1" class="program"></td> <!-- Blank column space for nested labels -->
-          <td colspan="4" class="sped"></td> <!-- Blank column space for nested labels -->
+          <td colspan="3" class="sped"></td> <!-- Blank column space for nested labels -->
           <td colspan="2" class="language"></td> <!-- Blank column space for nested labels -->
           <td colspan="1" class="free-reduced"></td> <!-- Blank column space for nested labels -->
           <td colspan="1" class="star"><p class="smalltype italic">Math</p></td>
@@ -73,7 +73,6 @@
           <th class="name"><span id="first-column-header" class="table-header">Name</span></th>
           <th class="risk sort-default" data-sort-method="reverse_number"><span class="table-header">Risk</span></th>
           <th class="program"><span class="table-header">Program Assigned</span></th>
-          <th class="sped"><span class="table-header">Placement</span></th>
           <th class="sped"><span class="table-header">Disability</span></th>
           <th class="sped"><span class="table-header">Level of Need</span></th>
           <th class="sped"><span class="table-header">504 Plan</span></th>


### PR DESCRIPTION
## What's new?

+ Make SPED info part of default roster view — critical info for educators
+ Take out SPED placement status column since this is info educators already know
+ Based on principal & educator feedback from Somerville via @marimuraki 

![sped roster](https://cloud.githubusercontent.com/assets/3209501/9239009/6d937f8c-410c-11e5-90bd-7b95d357adf2.png)
