### PR TITLE
Handle roster columns state with cookies

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -19,6 +19,7 @@
 //= require tablesort.min
 //= require tablesort.numeric
 //= require mustache.min
+//= require js.cookie
 //= require_tree ./sorts
 //= require roster
 //= require_tree ./charts

--- a/app/assets/javascripts/roster.js
+++ b/app/assets/javascripts/roster.js
@@ -11,22 +11,53 @@ $(function() {
       window.location.pathname = '/homerooms/' + $(this).val();
     });
 
-    // Show/hide column groups using Chosen plugin
-    $(".attendance").hide();
-    $(".discipline").hide();
-    $(".language").hide();
-    $(".star").hide();
-    $(".program").hide();
-    $(".free-reduced").hide();
-    $(".access").hide();
-    $(".dibels").hide();
+    function updateColumns () {
+      for (i = 0; i < roster_columns.length; i++) {
+        var column = roster_columns[i];
+        if (columns_selected.indexOf(column) === -1) {
+          $('.' + column).hide();
+        } else {
+          $('.' + column).show();
+        }
+      }
+    }
+
+    function updateCookies () {
+      Cookies.set("columns_selected", columns_selected);
+    }
+
+    // Show/hide column groups
+    var roster_columns = [
+      'attendance',
+      'discipline',
+      'language',
+      'star',
+      'program',
+      'free-reduced',
+      'access',
+      'dibels',
+      'name',
+      'risk',
+      'sped',
+      'mcas'
+    ];
+
+    var columns_selected = Cookies.getJSON("columns_selected");
+    console.log(columns_selected);
+    updateColumns();
+
     $("#column-group-select").chosen({width: "110%"}).on('change', function(e, params) {
       if (params.deselected !== undefined) {
         var assessment = params.deselected;
-        $('.' + assessment).hide();
+        var index = columns_selected.indexOf(assessment)
+        columns_selected.splice(index, 1);
+        updateCookies();
+        updateColumns();
       } else if (params.selected !== undefined) {
         var assessment = params.selected;
-        $('.' + assessment).show();
+        columns_selected.push(assessment)
+        updateCookies();
+        updateColumns();
       }
     });
 

--- a/app/controllers/homerooms_controller.rb
+++ b/app/controllers/homerooms_controller.rb
@@ -4,6 +4,8 @@ class HomeroomsController < ApplicationController
   before_action :assign_homeroom
 
   def show
+    cookies[:columns_selected] ||= ['name', 'risk', 'sped', 'mcas'].to_json
+
     student_attributes_sql = \
             "SELECT
               students.id as student_id,

--- a/app/views/homerooms/_student_row.html.erb
+++ b/app/views/homerooms/_student_row.html.erb
@@ -9,26 +9,40 @@
                       <%= presenter.risk_level_as_string %>
                     </div>
                   </td>
-                  <td class="program" href="<%= student_url(student) %>">
-                    <%= presenter.program_assigned %>
+                  <td class="program" href="<%= student_url(student) + "#demographics-row" %>">
+                    <div class="cell-wrapper">
+                      <%= presenter.program_assigned %>
+                    </div>
                   </td>
-                  <td class="sped" href="<%= student_url(student) %>">
-                    <%= presenter.disability %>
+                  <td class="sped" href="<%= student_url(student) + "#demographics-row" %>">
+                    <div class="cell-wrapper">
+                      <%= presenter.disability %>
+                    </div
                   </td>
-                  <td class="sped" href="<%= student_url(student) %>">
-                    <%= presenter.sped_level_of_need %>
+                  <td class="sped" href="<%= student_url(student) + "#demographics-row" %>">
+                    <div class="cell-wrapper">
+                      <%= presenter.sped_level_of_need %>
+                    </div
                   </td>
-                  <td class="sped" href="<%= student_url(student) %>">
-                    <%= presenter.plan_504 %>
+                  <td class="sped" href="<%= student_url(student) + "#demographics-row" %>">
+                    <div class="cell-wrapper">
+                      <%= presenter.plan_504 %>
+                    </div
                   </td>
-                  <td class="language" href="<%= student_url(student) %>">
-                    <%= presenter.limited_english_proficiency %>
+                  <td class="language" href="<%= student_url(student) + "#demographics-row" %>">
+                    <div class="cell-wrapper">
+                      <%= presenter.limited_english_proficiency %>
+                    </div
                   </td>
-                  <td class="language" href="<%= student_url(student) %>">
-                    <%= presenter.home_language %>
+                  <td class="language" href="<%= student_url(student) + "#demographics-row" %>">
+                    <div class="cell-wrapper">
+                      <%= presenter.home_language %>
+                    </div
                   </td>
-                  <td class="free-reduced" href="<%= student_url(student) %>">
-                    <%= presenter.free_reduced_lunch %>
+                  <td class="free-reduced" href="<%= student_url(student) + "#demographics-row" %>">
+                    <div class="cell-wrapper">
+                      <%= presenter.free_reduced_lunch %>
+                    </div
                   </td>
 
                   <%= render "star_math_row_fragment", student: student, presenter: StarValuePresenter.new(assessment_data[:star_math_row_data]) %>

--- a/app/views/homerooms/show.html.erb
+++ b/app/views/homerooms/show.html.erb
@@ -15,18 +15,42 @@
     </div>
     <div id="column-group-dropdown" class="dropdown">
       <select id="column-group-select" class="chosen-select" data-placeholder="Choose information to show..." tabindex="4" multiple>
-        <option value="name" selected>Name</option>
-        <option value="risk" selected>Risk Level</option>
-        <option value="program">Program</option>
-        <option value="language">Language</option>
-        <option value="free-reduced">Free/Reduced Lunch</option>
-        <option value="sped" selected>SPED & Disability</option>
-        <option value="star">STAR</option>
-        <option value="mcas" selected>MCAS</option>
-        <option value="access">ACCESS</option>
-        <option value="dibels">DIBELS</option>
-        <option value="attendance">Attendance</option>
-        <option value="discipline">Discipline</option>
+        <option value="name" <% if cookies[:columns_selected].include?("name") %>selected<% end %>>
+          Name
+        </option>
+        <option value="risk" <% if cookies[:columns_selected].include?("risk") %>selected<% end %>>
+            Risk Level
+        </option>
+        <option value="program" <% if cookies[:columns_selected].include?("program") %>selected<% end %>>
+          Program
+        </option>
+        <option value="language" <% if cookies[:columns_selected].include?("language") %>selected<% end %>>
+          Language
+        </option>
+        <option value="free-reduced" <% if cookies[:columns_selected].include?("free-reduced") %>selected<% end %>>
+          Free/Reduced Lunch
+        </option>
+        <option value="sped" <% if cookies[:columns_selected].include?("sped") %>selected<% end %>>
+          SPED & Disability
+        </option>
+        <option value="star" <% if cookies[:columns_selected].include?("star") %>selected<% end %>>
+          STAR
+        </option>
+        <option value="mcas" <% if cookies[:columns_selected].include?("mcas") %>selected<% end %>>
+          MCAS
+        </option>
+        <option value="access" <% if cookies[:columns_selected].include?("access") %>selected<% end %>>
+          ACCESS
+        </option>
+        <option value="dibels" <% if cookies[:columns_selected].include?("dibels") %>selected<% end %>>
+          DIBELS
+        </option>
+        <option value="attendance" <% if cookies[:columns_selected].include?("attendance") %>selected<% end %>>
+          Attendance
+        </option>
+        <option value="discipline" <% if cookies[:columns_selected].include?("discipline") %>selected<% end %>>
+          Discipline
+        </option>
       </select>
     </div>
   </div>

--- a/vendor/assets/javascripts/js.cookie.js
+++ b/vendor/assets/javascripts/js.cookie.js
@@ -1,0 +1,139 @@
+/*!
+ * JavaScript Cookie v2.0.3
+ * https://github.com/js-cookie/js-cookie
+ *
+ * Copyright 2006, 2015 Klaus Hartl & Fagner Brack
+ * Released under the MIT license
+ */
+(function (factory) {
+	if (typeof define === 'function' && define.amd) {
+		define(factory);
+	} else if (typeof exports === 'object') {
+		module.exports = factory();
+	} else {
+		var _OldCookies = window.Cookies;
+		var api = window.Cookies = factory();
+		api.noConflict = function () {
+			window.Cookies = _OldCookies;
+			return api;
+		};
+	}
+}(function () {
+	function extend () {
+		var i = 0;
+		var result = {};
+		for (; i < arguments.length; i++) {
+			var attributes = arguments[ i ];
+			for (var key in attributes) {
+				result[key] = attributes[key];
+			}
+		}
+		return result;
+	}
+
+	function init (converter) {
+		function api (key, value, attributes) {
+			var result;
+
+			// Write
+
+			if (arguments.length > 1) {
+				attributes = extend({
+					path: '/'
+				}, api.defaults, attributes);
+
+				if (typeof attributes.expires === 'number') {
+					var expires = new Date();
+					expires.setMilliseconds(expires.getMilliseconds() + attributes.expires * 864e+5);
+					attributes.expires = expires;
+				}
+
+				try {
+					result = JSON.stringify(value);
+					if (/^[\{\[]/.test(result)) {
+						value = result;
+					}
+				} catch (e) {}
+
+				value = encodeURIComponent(String(value));
+				value = value.replace(/%(23|24|26|2B|3A|3C|3E|3D|2F|3F|40|5B|5D|5E|60|7B|7D|7C)/g, decodeURIComponent);
+
+				key = encodeURIComponent(String(key));
+				key = key.replace(/%(23|24|26|2B|5E|60|7C)/g, decodeURIComponent);
+				key = key.replace(/[\(\)]/g, escape);
+
+				return (document.cookie = [
+					key, '=', value,
+					attributes.expires && '; expires=' + attributes.expires.toUTCString(), // use expires attribute, max-age is not supported by IE
+					attributes.path    && '; path=' + attributes.path,
+					attributes.domain  && '; domain=' + attributes.domain,
+					attributes.secure ? '; secure' : ''
+				].join(''));
+			}
+
+			// Read
+
+			if (!key) {
+				result = {};
+			}
+
+			// To prevent the for loop in the first place assign an empty array
+			// in case there are no cookies at all. Also prevents odd result when
+			// calling "get()"
+			var cookies = document.cookie ? document.cookie.split('; ') : [];
+			var rdecode = /(%[0-9A-Z]{2})+/g;
+			var i = 0;
+
+			for (; i < cookies.length; i++) {
+				var parts = cookies[i].split('=');
+				var name = parts[0].replace(rdecode, decodeURIComponent);
+				var cookie = parts.slice(1).join('=');
+
+				if (cookie.charAt(0) === '"') {
+					cookie = cookie.slice(1, -1);
+				}
+
+				try {
+					cookie = converter && converter(cookie, name) || cookie.replace(rdecode, decodeURIComponent);
+
+					if (this.json) {
+						try {
+							cookie = JSON.parse(cookie);
+						} catch (e) {}
+					}
+
+					if (key === name) {
+						result = cookie;
+						break;
+					}
+
+					if (!key) {
+						result[name] = cookie;
+					}
+				} catch (e) {}
+			}
+
+			return result;
+		}
+
+		api.get = api.set = api;
+		api.getJSON = function () {
+			return api.apply({
+				json: true
+			}, [].slice.call(arguments));
+		};
+		api.defaults = {};
+
+		api.remove = function (key, attributes) {
+			api(key, '', extend(attributes, {
+				expires: -1
+			}));
+		};
+
+		api.withConverter = init;
+
+		return api;
+	}
+
+	return init();
+}));


### PR DESCRIPTION
## What's new?

* When an educator switches back & forth between the roster and student profiles, column selects for the roster are maintained:

![use-cookies-for-state](https://cloud.githubusercontent.com/assets/3209501/9372710/9a764dd8-4696-11e5-9f85-b0c3b5770b44.gif)

* See #214.