### PR TITLE
add demographics information to profile CSV export #72

### DIFF
--- a/app/csv_exporters/student_profile_csv_demographic_section.rb
+++ b/app/csv_exporters/student_profile_csv_demographic_section.rb
@@ -1,0 +1,16 @@
+class StudentProfileCsvDemographicSection < Struct.new :csv, :exporter
+  delegate :student, to: :exporter
+
+  def add
+    csv << ['Demographics']
+    csv << ['Program Assigned', student.program_assigned]
+    csv << ['504 Plan', student.plan_504]
+    csv << ['Placement', student.sped_placement]
+    csv << ['Disability', student.disability]
+    csv << ['Level of Need', student.sped_level_of_need]
+    csv << ['Language Fluency', student.limited_english_proficiency]
+    csv << ['Home Language', student.home_language]
+    csv << []
+  end
+end
+

--- a/app/csv_exporters/student_profile_csv_exporter.rb
+++ b/app/csv_exporters/student_profile_csv_exporter.rb
@@ -8,6 +8,7 @@ class StudentProfileCsvExporter < Struct.new :student
 
   def profile_csv_export
     CSV.generate do |csv|
+      demographic_section(csv).add
       attendance_section(csv).add
       behavior_section(csv).add
       mcas_math_section(csv).add
@@ -15,6 +16,10 @@ class StudentProfileCsvExporter < Struct.new :student
       star_math_section(csv).add
       star_reading_section(csv).add
     end
+  end
+
+  def demographic_section(csv)
+    StudentProfileCsvDemographicSection.new(csv, self)
   end
 
   def attendance_section(csv)

--- a/spec/features/export_profile_feature_spec.rb
+++ b/spec/features/export_profile_feature_spec.rb
@@ -30,9 +30,9 @@ describe 'export profile', :type => :feature do
       end
       it 'sets the right values' do
         csv = CSV.parse(page.body)
-        expect(csv[0]).to eq ["Attendance"]
-        expect(csv[1]).to eq ["School Year", "Absences", "Tardies"]
-        expect(csv[2]).to eq ["2014-2015", "0", "0"]
+        expect(csv[0]).to eq ["Demographics"]
+        expect(csv[10]).to eq ["School Year", "Absences", "Tardies"]
+        expect(csv[11]).to eq ["2014-2015", "0", "0"]
       end
     end
   end


### PR DESCRIPTION
- previously CSV export only included {attendance, behavior, assessments}
- now includes demographics as listed in student profile
- updated specs

#72 