### PR TITLE
roster: nowrap for column group headers #240

### DIFF
--- a/app/assets/stylesheets/table.scss
+++ b/app/assets/stylesheets/table.scss
@@ -54,6 +54,7 @@ tr, td {
   td {
     padding-left: 0;
     padding-right: 20px;
+    white-space: nowrap;
   }
 
   td p {


### PR DESCRIPTION
Hi,

this css-change seems to fix the following issue:
The header broke into lines, when the header was wider than the content of the table cells (e.g. in the case "STAR: Math" - see #240 )

Please retest it.