### PR TITLE
Educator homeroom permissions

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -7,9 +7,12 @@ class ApplicationController < ActionController::Base
   before_filter :update_sanitized_params, if: :devise_controller?
 
   def update_sanitized_params
-    devise_parameter_sanitizer.for(:sign_in) do |u| 
+    devise_parameter_sanitizer.for(:sign_in) do |u|
       u.permit(:otp_attempt, :email, :password)
     end
   end
 
+  def not_found
+    raise ActionController::RoutingError.new('Not Found')
+  end
 end

--- a/app/controllers/homerooms_controller.rb
+++ b/app/controllers/homerooms_controller.rb
@@ -62,7 +62,8 @@ class HomeroomsController < ApplicationController
   end
 
   def assign_homeroom
-    @homeroom = Homeroom.friendly.find(params[:id])
+    @educator_homeroom = current_educator.homeroom || not_found
+    @requested_homeroom = Homeroom.friendly.find(params[:id])
   rescue ActiveRecord::RecordNotFound
     if current_educator.homeroom.present?
       @homeroom = current_educator.homeroom

--- a/app/controllers/homerooms_controller.rb
+++ b/app/controllers/homerooms_controller.rb
@@ -61,6 +61,20 @@ class HomeroomsController < ApplicationController
   end
 
   def authorize_and_assign_homeroom
+    if current_educator.admin?
+      assign_homeroom_for_admin
+    else
+      assign_homeroom_for_non_admin
+    end
+  end
+
+  def assign_homeroom_for_admin
+    @homeroom = Homeroom.friendly.find(params[:id])
+  rescue ActiveRecord::RecordNotFound   # params don't match a homeroom
+    redirect_to homeroom_path(Homeroom.first)
+  end
+
+  def assign_homeroom_for_non_admin
     @educator_homeroom = current_educator.homeroom || not_found
     @requested_homeroom = Homeroom.friendly.find(params[:id])
 

--- a/app/controllers/homerooms_controller.rb
+++ b/app/controllers/homerooms_controller.rb
@@ -30,7 +30,7 @@ class HomeroomsController < ApplicationController
 
     @risk_levels = @homeroom.student_risk_levels.group(:level).count
     @risk_levels['null'] = if @risk_levels.has_key? nil then @risk_levels[nil] else 0 end
-    @homerooms_by_name = Homeroom.where.not(name: "Demo").order(:name)
+    @homerooms_by_name = current_educator.allowed_homerooms_by_name
   end
 
   private

--- a/app/models/educator.rb
+++ b/app/models/educator.rb
@@ -2,4 +2,22 @@ class Educator < ActiveRecord::Base
   devise :database_authenticatable, :rememberable, :trackable, :validatable, :timeoutable
   has_one :homeroom
   has_many :students, through: :homerooms
+
+  def allowed_homerooms
+    # Educator can visit roster view for these homerooms
+    # For non-admins, all homerooms at their homeroom's grade level
+
+    if admin?
+      Homeroom.all
+    else
+      # Once the app includes data for multiple schools, will
+      # need to scope by school as well as by grade level
+      Homeroom.where(grade: homeroom.grade)
+    end
+  end
+
+  def allowed_homerooms_by_name
+    allowed_homerooms.order(:name)
+  end
+
 end

--- a/db/seeds/demo/demo_educator.seeds.rb
+++ b/db/seeds/demo/demo_educator.seeds.rb
@@ -1,2 +1,12 @@
-puts "Creating demo educator..."
-Educator.create(email: "demo@example.com", password: "demo-password")
+puts "Creating demo educators..."
+Educator.destroy_all
+
+Educator.create!([{
+  email: "demo@example.com",
+  password: "demo-password",
+  admin: true
+}, {
+  email: "fake-fifth-grade@example.com",
+  password: "demo-password",
+  admin: false
+}])

--- a/db/seeds/demo/demo_students.seeds.rb
+++ b/db/seeds/demo/demo_students.seeds.rb
@@ -7,10 +7,17 @@ healey = School.create(name: "Arthur D Healey")
 
 Homeroom.destroy_all
 n = 0
-4.times do |n|
-  Homeroom.create(name: "10#{n}")
+3.times do
+  Homeroom.create(name: "10#{n}", grade: "4")
   n += 1
 end
+3.times do
+  Homeroom.create(name: "10#{n}", grade: "5")
+  n += 1
+end
+
+fifth_grade_educator = Educator.find_by_email('fake-fifth-grade@example.com')
+Homeroom.last.update_attribute(:educator_id, fifth_grade_educator.id)
 
 Student.destroy_all
 StudentAssessment.destroy_all

--- a/spec/controllers/homerooms_controller_spec.rb
+++ b/spec/controllers/homerooms_controller_spec.rb
@@ -7,9 +7,9 @@ describe HomeroomsController, :type => :controller do
 
   describe '#show' do
 
-    def make_request(homeroom_slug = nil)
+    def make_request(slug = nil)
       request.env['HTTPS'] = 'on'
-      get :show, homeroom_id: homeroom_slug
+      get :show, id: slug
     end
 
     context 'when educator is not logged in' do
@@ -48,9 +48,9 @@ describe HomeroomsController, :type => :controller do
           it 'does not raise an error' do
             expect { make_request('garbage homeroom ids rule') }.not_to raise_error
           end
-          it 'assigns the educators homeroom' do
+          it 'redirects to educator\'s homeroom' do
             make_request('garbage homeroom ids rule')
-            expect(assigns(:homeroom)).to eq(educator.homeroom)
+            expect(response).to redirect_to(homeroom_path(educator.homeroom))
           end
         end
         context 'homeroom belongs to educator' do

--- a/spec/controllers/homerooms_controller_spec.rb
+++ b/spec/controllers/homerooms_controller_spec.rb
@@ -22,7 +22,7 @@ describe HomeroomsController, :type => :controller do
       before do
         sign_in(educator)
       end
-      context 'when there is no homeroom params' do
+      context 'no homeroom params' do
         it 'does not raise an error' do
           expect { make_request('garbage homeroom ids rule') }.not_to raise_error
         end
@@ -30,24 +30,46 @@ describe HomeroomsController, :type => :controller do
           make_request(educator.homeroom.slug)
           expect(assigns(:homeroom)).to eq(educator.homeroom)
         end
+        context 'when there are no students' do
+          before { make_request }
+          it 'is successful' do
+            make_request
+            expect(response).to be_success
+          end
+          it 'assigns rows to empty' do
+            expect(assigns(:rows)).to be_empty
+          end
+        end
+        context 'when there are students' do
+          let!(:first_student) { FactoryGirl.create(:student, homeroom: educator.homeroom) }
+          let!(:second_student) { FactoryGirl.create(:student, homeroom: educator.homeroom) }
+          before { make_request }
+          it 'assigns rows to a non-empty array' do
+            expect(assigns(:rows)).to be_a_kind_of Array
+            expect(assigns(:rows)).to_not be_empty
+          end
+        end
       end
-      context 'when there are no students' do
-        before { make_request }
+    end
+    context 'homeroom params' do
+      context 'homeroom belongs to educator' do
         it 'is successful' do
-          make_request
-          expect(response).to be_success
-        end
-        it 'assigns rows to empty' do
-          expect(assigns(:rows)).to be_empty
+
         end
       end
-      context 'when there are students' do
-        let!(:first_student) { FactoryGirl.create(:student, homeroom: educator.homeroom) }
-        let!(:second_student) { FactoryGirl.create(:student, homeroom: educator.homeroom) }
-        before { make_request }
-        it 'assigns rows to a non-empty array' do
-          expect(assigns(:rows)).to be_a_kind_of Array
-          expect(assigns(:rows)).to_not be_empty
+      context 'homeroom is same school and grade level as educator\'s' do
+        it 'is successful' do
+
+        end
+      end
+      context 'homeroom is different school, same grade level as educator\'s' do
+        it 'is not successful' do
+
+        end
+      end
+      context 'homeroom is different school and grade level as educator\'s' do
+        it 'is not successful' do
+
         end
       end
     end
@@ -56,9 +78,8 @@ describe HomeroomsController, :type => :controller do
         sign_in(educator_without_homeroom)
       end
       context 'when there is no homeroom params' do
-        it 'assigns the first homeroom' do
-          make_request('garbage homeroom ids rule')
-          expect(assigns(:homeroom)).to eq(Homeroom.first)
+        it 'redirects to error page' do
+
         end
       end
     end

--- a/spec/controllers/homerooms_controller_spec.rb
+++ b/spec/controllers/homerooms_controller_spec.rb
@@ -14,13 +14,13 @@ describe HomeroomsController, :type => :controller do
       get :show, id: slug
     end
 
-    context 'when educator is not logged in' do
+    context 'educator not logged in' do
       it 'redirects to sign in page' do
         make_request(educator.homeroom.slug)
         expect(response).to redirect_to(new_educator_session_path)
       end
     end
-    context 'when non-admin educator with homeroom is logged in' do
+    context 'non-admin educator with homeroom logged in' do
       before { sign_in(educator) }
       context 'no homeroom params' do
         before { make_request }
@@ -81,7 +81,7 @@ describe HomeroomsController, :type => :controller do
         end
       end
     end
-    context 'when admin educator is logged in' do
+    context 'admin educator logged in' do
       before { sign_in(admin_educator) }
       context 'no homeroom params' do
         it 'redirects to first homeroom' do
@@ -109,7 +109,7 @@ describe HomeroomsController, :type => :controller do
         end
       end
     end
-    context 'when non-admin without homeroom is logged in' do
+    context 'non-admin without homeroom logged in' do
       before { sign_in(educator_without_homeroom) }
       context 'no homeroom params' do
         it 'raises a error' do

--- a/spec/controllers/homerooms_controller_spec.rb
+++ b/spec/controllers/homerooms_controller_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 describe HomeroomsController, :type => :controller do
 
-  let!(:educator) { FactoryGirl.create(:educator_with_homeroom) }
+  let!(:educator) { FactoryGirl.create(:educator_with_grade_5_homeroom) }
   let!(:educator_without_homeroom) { FactoryGirl.create(:educator) }
 
   describe '#show' do
@@ -22,8 +22,8 @@ describe HomeroomsController, :type => :controller do
       before { sign_in(educator) }
       context 'no homeroom params' do
         before { make_request }
-        it 'is successful' do
-          expect(response).to be_success
+        it 'redirects to educator\'s homeroom' do
+          expect(response).to redirect_to(homeroom_path(educator.homeroom))
         end
         it 'assigns the educator\'s homeroom' do
           expect(assigns(:homeroom)).to eq(educator.homeroom)
@@ -43,36 +43,36 @@ describe HomeroomsController, :type => :controller do
           end
         end
       end
-    end
-    context 'homeroom params' do
-      context 'garbage params' do
-        it 'does not raise an error' do
-          expect { make_request('garbage homeroom ids rule') }.not_to raise_error
+      context 'homeroom params' do
+        context 'garbage params' do
+          it 'does not raise an error' do
+            expect { make_request('garbage homeroom ids rule') }.not_to raise_error
+          end
+          it 'assigns the educators homeroom' do
+            make_request('garbage homeroom ids rule')
+            expect(assigns(:homeroom)).to eq(educator.homeroom)
+          end
         end
-        it 'assigns the educators homeroom' do
-          make_request('garbage homeroom ids rule')
-          expect(assigns(:homeroom)).to eq(educator.homeroom)
-        end
-      end
-      context 'homeroom belongs to educator' do
-        it 'is successful' do
-          make_request(educator.homeroom.slug)
-          expect(response).to be_success
-        end
-      end
-      context 'homeroom does not belong to educator' do
-        context 'homeroom is grade level as educator\'s' do
-          let(:homeroom) { FactoryGirl.create(:homeroom_in_same_school_and_grade_level_as_educator_homeroom) }
+        context 'homeroom belongs to educator' do
           it 'is successful' do
-            make_request(homeroom.slug)
+            make_request(educator.homeroom.slug)
             expect(response).to be_success
           end
         end
-        context 'homeroom is different grade level from educator\'s' do
-          let(:homeroom) { FactoryGirl.create(:homeroom) }
-          it 'redirects to educator\'s homeroom' do
-            make_request(homeroom.slug)
-            expect(response).to redirect_to(homeroom_path(educator.homeroom))
+        context 'homeroom does not belong to educator' do
+          context 'homeroom is grade level as educator\'s' do
+            let(:homeroom) { FactoryGirl.create(:grade_5_homeroom) }
+            it 'is successful' do
+              make_request(homeroom.slug)
+              expect(response).to be_success
+            end
+          end
+          context 'homeroom is different grade level from educator\'s' do
+            let(:homeroom) { FactoryGirl.create(:homeroom) }
+            it 'redirects to educator\'s homeroom' do
+              make_request(homeroom.slug)
+              expect(response).to redirect_to(homeroom_path(educator.homeroom))
+            end
           end
         end
       end

--- a/spec/controllers/homerooms_controller_spec.rb
+++ b/spec/controllers/homerooms_controller_spec.rb
@@ -5,6 +5,8 @@ describe HomeroomsController, :type => :controller do
   let!(:educator) { FactoryGirl.create(:educator_with_grade_5_homeroom) }
   let!(:educator_without_homeroom) { FactoryGirl.create(:educator) }
   let!(:admin_educator) { FactoryGirl.create(:admin_educator) }
+  let(:first_homeroom_path) { homeroom_path(Homeroom.first) }
+
   describe '#show' do
 
     def make_request(slug = nil)
@@ -79,18 +81,22 @@ describe HomeroomsController, :type => :controller do
       before { sign_in(admin_educator) }
       context 'no homeroom params' do
         it 'redirects to first homeroom' do
-
+          make_request
+          expect(response).to redirect_to(first_homeroom_path)
         end
       end
       context 'homeroom params' do
         context 'good homeroom params' do
+          let(:homeroom) { FactoryGirl.create(:grade_5_homeroom) }
           it 'is successful' do
-
+            make_request(homeroom.slug)
+            expect(response).to be_success
           end
         end
         context 'garbage homeroom params' do
           it 'redirects to first homeroom' do
-
+            make_request('garbage homeroom ids rule')
+            expect(response).to redirect_to(first_homeroom_path)
           end
         end
       end

--- a/spec/controllers/homerooms_controller_spec.rb
+++ b/spec/controllers/homerooms_controller_spec.rb
@@ -4,7 +4,7 @@ describe HomeroomsController, :type => :controller do
 
   let!(:educator) { FactoryGirl.create(:educator_with_grade_5_homeroom) }
   let!(:educator_without_homeroom) { FactoryGirl.create(:educator) }
-
+  let!(:admin_educator) { FactoryGirl.create(:admin_educator) }
   describe '#show' do
 
     def make_request(slug = nil)
@@ -18,7 +18,7 @@ describe HomeroomsController, :type => :controller do
         expect(response).to redirect_to(new_educator_session_path)
       end
     end
-    context 'when educator with homeroom is logged in' do
+    context 'when non-admin educator with homeroom is logged in' do
       before { sign_in(educator) }
       context 'no homeroom params' do
         before { make_request }
@@ -75,7 +75,27 @@ describe HomeroomsController, :type => :controller do
         end
       end
     end
-    context 'when educator without homeroom is logged in' do
+    context 'when admin educator is logged in' do
+      before { sign_in(admin_educator) }
+      context 'no homeroom params' do
+        it 'redirects to first homeroom' do
+
+        end
+      end
+      context 'homeroom params' do
+        context 'good homeroom params' do
+          it 'is successful' do
+
+          end
+        end
+        context 'garbage homeroom params' do
+          it 'redirects to first homeroom' do
+
+          end
+        end
+      end
+    end
+    context 'when non-admin without homeroom is logged in' do
       before { sign_in(educator_without_homeroom) }
       context 'no homeroom params' do
         it 'raises a error' do

--- a/spec/controllers/homerooms_controller_spec.rb
+++ b/spec/controllers/homerooms_controller_spec.rb
@@ -19,23 +19,16 @@ describe HomeroomsController, :type => :controller do
       end
     end
     context 'when educator with homeroom is logged in' do
-      before do
-        sign_in(educator)
-      end
+      before { sign_in(educator) }
       context 'no homeroom params' do
-        it 'does not raise an error' do
-          expect { make_request('garbage homeroom ids rule') }.not_to raise_error
+        before { make_request }
+        it 'is successful' do
+          expect(response).to be_success
         end
-        it 'assigns the educators homeroom' do
-          make_request(educator.homeroom.slug)
+        it 'assigns the educator\'s homeroom' do
           expect(assigns(:homeroom)).to eq(educator.homeroom)
         end
         context 'when there are no students' do
-          before { make_request }
-          it 'is successful' do
-            make_request
-            expect(response).to be_success
-          end
           it 'assigns rows to empty' do
             expect(assigns(:rows)).to be_empty
           end
@@ -43,8 +36,8 @@ describe HomeroomsController, :type => :controller do
         context 'when there are students' do
           let!(:first_student) { FactoryGirl.create(:student, homeroom: educator.homeroom) }
           let!(:second_student) { FactoryGirl.create(:student, homeroom: educator.homeroom) }
-          before { make_request }
           it 'assigns rows to a non-empty array' do
+            make_request
             expect(assigns(:rows)).to be_a_kind_of Array
             expect(assigns(:rows)).to_not be_empty
           end
@@ -52,34 +45,49 @@ describe HomeroomsController, :type => :controller do
       end
     end
     context 'homeroom params' do
+      context 'garbage params' do
+        it 'does not raise an error' do
+          expect { make_request('garbage homeroom ids rule') }.not_to raise_error
+        end
+        it 'assigns the educators homeroom' do
+          make_request('garbage homeroom ids rule')
+          expect(assigns(:homeroom)).to eq(educator.homeroom)
+        end
+      end
       context 'homeroom belongs to educator' do
         it 'is successful' do
-
+          make_request(educator.homeroom.slug)
+          expect(response).to be_success
         end
       end
-      context 'homeroom is same school and grade level as educator\'s' do
-        it 'is successful' do
-
+      context 'homeroom does not belong to educator' do
+        context 'homeroom is grade level as educator\'s' do
+          let(:homeroom) { FactoryGirl.create(:homeroom_in_same_school_and_grade_level_as_educator_homeroom) }
+          it 'is successful' do
+            make_request(homeroom.slug)
+            expect(response).to be_success
+          end
         end
-      end
-      context 'homeroom is different school, same grade level as educator\'s' do
-        it 'is not successful' do
-
-        end
-      end
-      context 'homeroom is different school and grade level as educator\'s' do
-        it 'is not successful' do
-
+        context 'homeroom is different grade level from educator\'s' do
+          let(:homeroom) { FactoryGirl.create(:homeroom) }
+          it 'redirects to educator\'s homeroom' do
+            make_request(homeroom.slug)
+            expect(response).to redirect_to(homeroom_path(educator.homeroom))
+          end
         end
       end
     end
     context 'when educator without homeroom is logged in' do
-      before do
-        sign_in(educator_without_homeroom)
+      before { sign_in(educator_without_homeroom) }
+      context 'no homeroom params' do
+        it 'raises a error' do
+          expect { make_request }.to raise_error ActionController::RoutingError
+        end
       end
-      context 'when there is no homeroom params' do
-        it 'redirects to error page' do
-
+      context 'homeroom params' do
+        let!(:homeroom) { FactoryGirl.create(:homeroom) }
+        it 'raises a error' do
+          expect { make_request(homeroom.slug) }.to raise_error ActionController::RoutingError
         end
       end
     end

--- a/spec/controllers/homerooms_controller_spec.rb
+++ b/spec/controllers/homerooms_controller_spec.rb
@@ -25,23 +25,6 @@ describe HomeroomsController, :type => :controller do
         it 'redirects to educator\'s homeroom' do
           expect(response).to redirect_to(homeroom_path(educator.homeroom))
         end
-        it 'assigns the educator\'s homeroom' do
-          expect(assigns(:homeroom)).to eq(educator.homeroom)
-        end
-        context 'when there are no students' do
-          it 'assigns rows to empty' do
-            expect(assigns(:rows)).to be_empty
-          end
-        end
-        context 'when there are students' do
-          let!(:first_student) { FactoryGirl.create(:student, homeroom: educator.homeroom) }
-          let!(:second_student) { FactoryGirl.create(:student, homeroom: educator.homeroom) }
-          it 'assigns rows to a non-empty array' do
-            make_request
-            expect(assigns(:rows)).to be_a_kind_of Array
-            expect(assigns(:rows)).to_not be_empty
-          end
-        end
       end
       context 'homeroom params' do
         context 'garbage params' do
@@ -57,6 +40,21 @@ describe HomeroomsController, :type => :controller do
           it 'is successful' do
             make_request(educator.homeroom.slug)
             expect(response).to be_success
+          end
+          context 'when there are no students' do
+            it 'assigns rows to empty' do
+              make_request(educator.homeroom.slug)
+              expect(assigns(:rows)).to be_empty
+            end
+          end
+          context 'when there are students' do
+            let!(:first_student) { FactoryGirl.create(:student, homeroom: educator.homeroom) }
+            let!(:second_student) { FactoryGirl.create(:student, homeroom: educator.homeroom) }
+            it 'assigns rows to a non-empty array' do
+              make_request(educator.homeroom.slug)
+              expect(assigns(:rows)).to be_a_kind_of Array
+              expect(assigns(:rows)).to_not be_empty
+            end
           end
         end
         context 'homeroom does not belong to educator' do

--- a/spec/controllers/homerooms_controller_spec.rb
+++ b/spec/controllers/homerooms_controller_spec.rb
@@ -43,6 +43,10 @@ describe HomeroomsController, :type => :controller do
             make_request(educator.homeroom.slug)
             expect(response).to be_success
           end
+          it 'assigns correct homerooms to drop-down' do
+            make_request(educator.homeroom.slug)
+            expect(assigns(:homerooms_by_name)).to eq([educator.homeroom])
+          end
           context 'when there are no students' do
             it 'assigns rows to empty' do
               make_request(educator.homeroom.slug)
@@ -91,6 +95,10 @@ describe HomeroomsController, :type => :controller do
           it 'is successful' do
             make_request(homeroom.slug)
             expect(response).to be_success
+          end
+          it 'assigns correct homerooms to drop-down' do
+            make_request(homeroom.slug)
+            expect(assigns(:homerooms_by_name)).to eq(Homeroom.order(:name))
           end
         end
         context 'garbage homeroom params' do

--- a/spec/factories/educators.rb
+++ b/spec/factories/educators.rb
@@ -11,6 +11,11 @@ FactoryGirl.define do
         create(:homeroom, educator: educator)
       end
     end
+    factory :educator_with_grade_5_homeroom do
+      after(:create) do |educator|
+        create(:homeroom, educator: educator, grade: "5")
+      end
+    end
     factory :educator_with_homeroom_with_student do
       after(:create) do |educator|
         homeroom = create(:homeroom, educator: educator)

--- a/spec/factories/educators.rb
+++ b/spec/factories/educators.rb
@@ -6,6 +6,9 @@ FactoryGirl.define do
     password "PairShareCompare"
     email { FactoryGirl.generate(:email) }
 
+    factory :admin_educator do
+      admin true
+    end
     factory :educator_with_homeroom do
       after(:create) do |educator|
         create(:homeroom, educator: educator)

--- a/spec/factories/homerooms.rb
+++ b/spec/factories/homerooms.rb
@@ -4,6 +4,9 @@ FactoryGirl.define do
 
   factory :homeroom do
     name { FactoryGirl.generate(:name) }
+    factory :grade_5_homeroom do
+      grade "5"
+    end
     factory :homeroom_with_student do
       after(:create) do |homeroom|
         homeroom.students << FactoryGirl.create(:student)


### PR DESCRIPTION
## What's new?

+ Admin-level educators can see roster view for all homerooms
+ Non-admin educators can only see the roster for their own homerooms, plus other homerooms at their grade level, as per feedback we've gotten from Healey teachers and @jsgeiser
+ In demo mode, add a new login: `fake-fifth-grade@example.com` / `demo-password`, which can only see fifth-grade demo classrooms