### PR TITLE
access returns MissingStudentAssessment as nil object instead of MissingStudentAssessmentCollection

### DIFF
--- a/app/models/student.rb
+++ b/app/models/student.rb
@@ -50,8 +50,8 @@ class Student < ActiveRecord::Base
     end
     def access
       star_reading = Assessment.access
-      return MissingStudentAssessmentCollection.new if Assessment.access.is_a? MissingAssessment
-      where(assessment_id: Assessment.access.id).last_or_missing || MissingStudentAssessmentCollection.new
+      return MissingStudentAssessment.new if Assessment.access.is_a? MissingAssessment
+      where(assessment_id: Assessment.access.id).last_or_missing || MissingStudentAssessment.new
     end
   end
   has_many :assessments, through: :student_assessments

--- a/app/views/students/_school_year_box.html.erb
+++ b/app/views/students/_school_year_box.html.erb
@@ -86,7 +86,7 @@
     <% end %>
 
     <!-- ACCESS -->
-    <% unless events[:access].is_a?(MissingStudentAssessmentCollection) %>
+    <% unless events[:access].is_a?(MissingStudentAssessment) %>
       <div class="section access-result-section">
         <h2 class="section-header">ACCESS</h2>
         <h3 class="assessment-type">Overall</h3>


### PR DESCRIPTION
Hi,

while writing tests for the new risk level calculation, I noticed a small inconsistency - which made writing tests for access results a little bit more difficult.

In the model Student:
the method access returns a single access assessment,
but it can also return a MissingStudentAssessmentCollection, if some data is missing.

The other methods which return only a single assessment, always return MissingStudentAssessment as "nil object".

Does this have a specific reason?
If not, please review this pull request :-)

Cheers,
r11runner