### PR TITLE
readme: added note about configuring the dev db on a Debian-like system

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,12 @@ Student Insights enables educators to see at-risk students and match them to the
 ## Installation
 This is a Ruby on Rails app and uses a PostgreSQL database. See Code for America's "HowTo" on Rails for more information on deploying and maintaining apps using Rails: https://github.com/codeforamerica/howto/blob/master/Rails.md
 
+On a Debian-like OS you may have to remove this line from the config of the development database (config/database.yml)
+```
+host: localhost
+```
+(For an explanation see [this Stackoverflow discussion](http://stackoverflow.com/questions/23375740/pgconnectionbad-fe-sendauth-no-password-supplied))
+
 ### Setting up demo data
 
 To set up demo data after you clone the project, run


### PR DESCRIPTION
Hi,

I've just tried to set up the somerville-teacher-tool project on my old-new laptop with Ubuntu 15.04 and I've run (again) into this issue.
```
rake db:create
```
throws an error, unless I remove the line
```
host: localhost
```
from the config of the development db. (The test db gets created as expected.) Ca. 2 months ago, I had the same issue on an Ubuntu 14.04 system.

According to [this Stackoverflow-discussion](http://stackoverflow.com/questions/23375740/pgconnectionbad-fe-sendauth-no-password-supplied), on Debian-like systems localhost refers to a TCP connection => password is required. So
 - either I have to set "host: localhost", username and password
 - or also omit the line "host: localhost"

Feel free this reject this pull request or replace it with a better / more detailed explanation :-)

Cheers,
r11runner