### PR TITLE
Give educator a "renew session" link

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -26,6 +26,7 @@
 //= require_tree ./charts
 //= require profile
 //= require profile_interventions
+//= require session_timeout_warning
 //= require datepicker
 //= require rounded-corners
 //= require student-searchbar

--- a/app/assets/javascripts/session_timeout_warning.js
+++ b/app/assets/javascripts/session_timeout_warning.js
@@ -17,7 +17,8 @@
 $(function() {
 
   if ($('body').hasClass('educator-signed-in')) {
-    (new SessionTimeoutWarning).count();
+    var warning = new SessionTimeoutWarning;
+    warning.count();
   }
 
   $("#renew-sesion-link").click(function () {
@@ -25,6 +26,7 @@ $(function() {
       url: '/educators/reset',
       success: function () {
         $('#renew-session').slideUp();
+        warning.count();   // Resent timeout count
       }
     });
   });

--- a/app/assets/javascripts/session_timeout_warning.js
+++ b/app/assets/javascripts/session_timeout_warning.js
@@ -1,0 +1,31 @@
+(function(root) {
+
+  var SessionTimeoutWarning = function () {}
+
+  SessionTimeoutWarning.prototype.count = function () {
+    root.setTimeout(this.show, 780000);  // count up to 13 minutes
+  };
+
+  SessionTimeoutWarning.prototype.show = function () {
+    $('#renew-session').slideDown();
+  };
+
+  root.SessionTimeoutWarning = SessionTimeoutWarning;
+
+})(window)
+
+$(function() {
+
+  if ($('body').hasClass('educator-signed-in')) {
+    (new SessionTimeoutWarning).count();
+  }
+
+  $("#renew-sesion-link").click(function () {
+    $.ajax({
+      url: '/educators/reset',
+      success: function () {
+        $('#renew-session').slideUp();
+      }
+    });
+  });
+});

--- a/app/assets/stylesheets/nav.scss
+++ b/app/assets/stylesheets/nav.scss
@@ -1,5 +1,20 @@
 /* NAV */
 
+#renew-session {
+  background-color: $blue;
+  color: white;
+  text-align: center;
+  padding: 10px;
+  position: relative;
+  top: -10px;
+  display: none;
+  a {
+    color: white;
+    text-decoration: underline;
+    font-size: 16px;
+  }
+}
+
 .nav {
   border-bottom: 1px solid $light-line;
   background-color: $white;

--- a/app/controllers/educators_controller.rb
+++ b/app/controllers/educators_controller.rb
@@ -1,2 +1,11 @@
 class EducatorsController < ApplicationController
+
+  def reset_session_clock
+    # Send arbitrary request to reset Devise Timeoutable
+
+    respond_to do |format|
+      format.json { render json: :ok }
+    end
+  end
+
 end

--- a/app/controllers/educators_controller.rb
+++ b/app/controllers/educators_controller.rb
@@ -1,5 +1,7 @@
 class EducatorsController < ApplicationController
 
+  before_action :authenticate_educator!
+
   def reset_session_clock
     # Send arbitrary request to reset Devise Timeoutable
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -7,27 +7,30 @@
     <%= javascript_include_tag 'application', 'data-turbolinks-track' => false %>
     <%= csrf_meta_tags %>
   </head>
-  <body class="<%= controller_name %> <%= action_name %>">
+  <body class="<%= controller_name %> <%= action_name %> <%= if educator_signed_in? then "educator-signed-in" end %>">
     <div class="nav">
+      <div id="renew-session">
+        Please click <a href="#" id="renew-sesion-link">this link</a> or your session will timeout due to inactivity.
+      </div>
       <div class="navwrap">
-          <div id="logo">
-            <div id="title" alt="Student Insights"></div>
-          </div>
-          <nav>
-            <% if educator_signed_in? %>
-              <% if controller_name == 'pages' %>
-                <%= link_to "Roster", roster_url %>
-              <% end %>
-              <div class="nav-options">
-                <p>Search for student:</p>
-                <input id="student-searchbar" />
-              </div>
-              <%= link_to "Sign Out", destroy_educator_session_path, method: :delete %>
-            <% else %>
-              <%= link_to "About", about_url %>
-              <%= link_to "Sign In", new_educator_session_path %>
+        <div id="logo">
+          <div id="title" alt="Student Insights"></div>
+        </div>
+        <nav>
+          <% if educator_signed_in? %>
+            <% if controller_name == 'pages' %>
+              <%= link_to "Roster", roster_url %>
             <% end %>
-          </nav>
+            <div class="nav-options">
+              <p>Search for student:</p>
+              <input id="student-searchbar" />
+            </div>
+            <%= link_to "Sign Out", destroy_educator_session_path, method: :delete %>
+          <% else %>
+            <%= link_to "About", about_url %>
+            <%= link_to "Sign In", new_educator_session_path %>
+          <% end %>
+        </nav>
         <p class="notice field"><%= notice %></p>
         <p class="alert field"><%= alert %></p>
       </div>

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -153,7 +153,7 @@ Devise.setup do |config|
   # ==> Configuration for :timeoutable
   # The time you want to timeout the user session without activity. After this
   # time the user will be asked for credentials again. Default is 30 minutes.
-  config.timeout_in = Rails.env.development? ? 120.minutes : 10.minutes
+  config.timeout_in = Rails.env.development? ? 30.minutes : 15.minutes
 
   # ==> Configuration for :lockable
   # Defines which strategy will be used to lock an account.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,6 +11,8 @@ Rails.application.routes.draw do
   get 'demo' => 'pages#roster_demo'
 
   get '/students/names' => 'students#names'
+  get '/educators/reset'=> 'educators#reset_session_clock'
+
   resources :students
   resources :homerooms
   resources :interventions

--- a/spec/controllers/educators_controller_spec.rb
+++ b/spec/controllers/educators_controller_spec.rb
@@ -1,0 +1,33 @@
+require 'rails_helper'
+
+describe EducatorsController, :type => :controller do
+
+  describe '#reset_session_clock' do
+    def make_request
+      request.env['HTTPS'] = 'on'
+      request.env["devise.mapping"] = Devise.mappings[:educator]
+      get :reset_session_clock, format: :json
+    end
+
+    context 'educator is not logged in' do
+      it 'returns 401 Unauthorized' do
+        make_request
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+    context 'educator is logged in' do
+      before(:each) do
+        sign_in FactoryGirl.create(:educator)
+        make_request
+      end
+      it 'succeeds' do
+        expect(response).to have_http_status(:success)
+      end
+      it 'resets the session clock' do
+        # TODO: Get Devise test helpers like `educator_session`
+        # working within the Rspec controller context:
+        # expect(educator_session["last_request_at"]).eq Time.now
+      end
+    end
+  end
+end


### PR DESCRIPTION
# What's new?

+ Client-side option to renew sessions, which expire automatically after 15 minutes with Devise `timeoutable` on the server side
+ Important to have because educators were finding their flow interrupted by unexpected timeout when clicking a link on the page
+ #326

## GIF

![tweak-timeoutable](https://cloud.githubusercontent.com/assets/3209501/10910495/b6101e22-820d-11e5-9cb4-769d608a7610.gif)