### PR TITLE
Add minimal classrooms page and navigation links to the header

### DIFF
--- a/app/assets/stylesheets/nav.scss
+++ b/app/assets/stylesheets/nav.scss
@@ -25,6 +25,10 @@
   }
 }
 
+.search-label {
+  padding-left: 20px;
+}
+
 .navwrap {
   width: 80%;
   margin: 20px auto 30px auto;
@@ -38,7 +42,7 @@
       padding-top: 38px;
 
       a {
-        padding-left: 20px;
+        padding-right: 10px;
 
         @media screen and (max-width: $phase2) {
           padding-right: 20px;

--- a/app/controllers/schools_controller.rb
+++ b/app/controllers/schools_controller.rb
@@ -13,4 +13,14 @@ class SchoolsController < ApplicationController
     @top_mcas_ela_concerns = mcas_queries.top_5_ela_concerns_serialized
   end
 
+  def homerooms
+    @school = School.friendly.find(params[:id])
+    homerooms = @school.students.map(&:homeroom).compact.uniq
+    homeroom_queries = HomeroomQueries.new(homerooms)
+
+    @top_absences = homeroom_queries.top_absences
+    @top_tardies = homeroom_queries.top_tardies
+    @top_mcas_math_concerns = homeroom_queries.top_mcas_math_concerns
+    @top_mcas_ela_concerns = homeroom_queries.top_mcas_ela_concerns
+  end
 end

--- a/app/models/educator.rb
+++ b/app/models/educator.rb
@@ -1,7 +1,7 @@
 class Educator < ActiveRecord::Base
   devise :database_authenticatable, :rememberable, :trackable, :validatable, :timeoutable
   has_one :homeroom
-  has_many :students, through: :homerooms
+  has_many :students, through: :homeroom
   has_many :interventions
   has_many :progress_notes, through: :interventions
   has_many :student_notes

--- a/app/models/homeroom_queries.rb
+++ b/app/models/homeroom_queries.rb
@@ -1,0 +1,79 @@
+# This class performs queries for the /schools/:id/classrooms endpoint.
+class HomeroomQueries
+  def initialize(homerooms)
+    @homerooms = homerooms
+  end
+
+  def top_absences
+    @homerooms.map {|homeroom| attendance_response(homeroom, :absences_count_most_recent_school_year) }
+  end
+
+  def top_tardies
+    @homerooms.map {|homeroom| attendance_response(homeroom, :tardies_count_most_recent_school_year) }
+  end
+
+  def top_mcas_ela_concerns
+    mcas_concerns(:most_recent_mcas_math_scaled)
+  end
+
+  def top_mcas_math_concerns
+    mcas_concerns(:most_recent_mcas_ela_scaled)
+  end
+
+  private
+  def mcas_concerns(method_name)
+    homeroom_rows = @homerooms.map do |homeroom|
+      # guard for missing mcas scores
+      values = homeroom.students.map {|student| student.send(method_name) }.compact
+      result_value = if values.size == 0 then nil else (values.reduce(:+).to_f / values.size).round(0) end
+      {
+        :id => homeroom.id,
+        :name => homeroom.name,
+        :result_value => result_value,
+        :interventions_count => recent_interventions_for(homeroom.students, math_interventions).length || 0
+      }
+    end
+    homeroom_rows.sort {|a, b| a[:result_value] <=> b[:result_value] } 
+  end
+
+  def attendance_response(homeroom, method_name)
+    {
+      :id => homeroom.id,
+      :name => homeroom.name,
+      :result_value => homeroom.students.map {|student| student.send(method_name) }.compact.reduce(:+),
+      :interventions_count => recent_interventions_for(homeroom.students, attendance_interventions).length || 0
+    }
+  end
+
+  def math_interventions
+    generic_interventions + InterventionType.where(name: [
+      'After-School Tutoring (ATP)',
+      'Classroom Academic Intervention',
+      'Math Tutor'
+    ])
+  end
+
+  def attendance_interventions
+    generic_interventions + InterventionType.where(name: [
+      'Attendance Officer',
+      'Attendance Contract'
+    ])
+  end
+
+  def generic_interventions
+    InterventionType.where(name: [
+      'MTSS Referral',
+      'Other',
+      'SST Referral',
+      '51a Filing'
+    ])
+  end
+
+  def recent_interventions_for(students, interventions)
+    intervention_ids = interventions.map(&:id)
+    all_interventions = students.map do |student|
+      student.most_recent_school_year.try(:interventions)
+    end.flatten.compact
+    all_interventions.select {|it| intervention_ids.include?(it.id) }
+  end
+end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -22,7 +22,13 @@
               <%= link_to "Roster", roster_url %>
             <% end %>
             <div class="nav-options">
-              <p>Search for student:</p>
+              <% current_school = current_educator.try(:allowed_homerooms).try(:first).try(:students).try(:first).try(:school) %>
+              <% if educator_signed_in? && current_school.present? %>
+                <p>At risk:</p>
+                <%= link_to 'Students', school_path(current_school.id) %>
+                <%= link_to 'Classrooms', homerooms_school_path(current_school.id) %>
+              <% end %>
+              <p class="search-label">Search for student:</p>
               <input id="student-searchbar" />
             </div>
             <%= link_to "Sign Out", destroy_educator_session_path, method: :delete %>

--- a/app/views/schools/_homeroom_table.html.erb
+++ b/app/views/schools/_homeroom_table.html.erb
@@ -1,0 +1,25 @@
+        <table class="dashboard-table bigtype">
+          <thead>
+            <tr>
+              <th>Name</th>
+              <th><%= header %></th>
+              <th>Interventions</th>
+            </tr>
+          </thead>
+          <tbody>
+            <% homerooms.each do |homeroom| %>
+              <tr>
+                <td><%= link_to homeroom[:name], homeroom_path(homeroom[:id]), class: "bigtype" %></td>
+                <td><%= homeroom[:result_value] %></td>
+                <td>
+                  <% if homeroom[:interventions_count] == 0 then %>
+                    <span class="warning-text"><%= homeroom[:interventions_count] %></span>
+                  <% else %>
+                    <%= homeroom[:interventions_count] %>
+                  <% end %>
+                </td>
+              </tr>
+          <% end %>
+          </tbody>
+        </table>
+        <br/>

--- a/app/views/schools/homerooms.erb
+++ b/app/views/schools/homerooms.erb
@@ -1,25 +1,25 @@
 <div class="school-dashboard info-area">
   <div class="topline-info underline">
-    <h1>Students at Risk: <%= @school.name %></h1>
+    <h1>Classrooms at Risk: <%= @school.name %></h1>
   </div>
   <div class="detailed-content-area">
     <div class="left-panel">
       <div class="mcas-math-concern">
         <h2>Math: MCAS</h2>
-        <%= render "student_table", students: @top_mcas_math_concerns, header: 'Score' %>
+        <%= render "homeroom_table", homerooms: @top_mcas_math_concerns, header: 'Average Score' %>
       </div>
       <div class="mcas-ela-concern">
         <h2>ELA: MCAS</h2>
-        <%= render "student_table", students: @top_mcas_ela_concerns, header: 'Score' %>
+        <%= render "homeroom_table", homerooms: @top_mcas_ela_concerns, header: 'Average Score' %>
       </div>
       <p><em>Data reflect most recent available MCAS results.</em></p>
     </div>
     <div class="right-panel">
       <div class="attendance-section">
         <h2>Attendance: Absences</h2>
-        <%= render "student_table", students: @top_absences, header: 'Absences' %>
+        <%= render "homeroom_table", homerooms: @top_absences, header: 'Absences' %>
         <h2>Attendance: Tardies</h2>
-        <%= render "student_table", students: @top_tardies, header: 'Tardies' %>
+        <%= render "homeroom_table", homerooms: @top_tardies, header: 'Tardies' %>
         <p><em>Data reflect absences and tardies during this current school year.</em></p>
       </div>
     </div>

--- a/app/views/students/show.html.erb
+++ b/app/views/students/show.html.erb
@@ -1,6 +1,6 @@
   <div id="controls">
     <div id="roster-back">
-      <%= link_to "< Back to Roster", @roster_url %>
+      <%= link_to "< Back to roster for #{@student.homeroom.name}", @roster_url %>
     </div>
     <div id="export">
       <%= link_to "Export &#9662;".html_safe, @csv_url, method: "get", id: 'export-button' %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,5 +18,7 @@ Rails.application.routes.draw do
   resources :progress_notes
   resources :student_notes
   resources :bulk_intervention_assignments
-  resources :schools
+  resources :schools do
+    get :homerooms, on: :member
+  end
 end

--- a/spec/controllers/schools_controller_spec.rb
+++ b/spec/controllers/schools_controller_spec.rb
@@ -28,7 +28,26 @@ describe SchoolsController, :type => :controller do
         expect(assigns(:school)).to eq(school)
       end
     end
-
   end
 
+  describe '#homerooms' do
+    before { sign_in(educator) }
+    let!(:school) { FactoryGirl.create(:healey) }
+    let!(:alpha_homeroom) { FactoryGirl.create(:homeroom, name: 'alpha') }
+    let!(:beta_homeroom) { FactoryGirl.create(:homeroom, name: 'beta') }
+    let!(:alpha_students) { 3.times {|i| FactoryGirl.create(:student, homeroom: alpha_homeroom, school: school) } }
+    let!(:beta_students) { 3.times {|i| FactoryGirl.create(:student, homeroom: beta_homeroom, school: school) } }
+    let!(:educator) { FactoryGirl.create(:admin_educator) }
+
+    it 'no exceptions on the happy path' do
+      request.env['HTTPS'] = 'on'
+      get :homerooms, id: school.slug
+
+      expect(response).to be_success
+      expect(assigns(:top_absences).map {|row| row[:name] }).to eq(['beta', 'alpha'])
+      expect(assigns(:top_tardies).map {|row| row[:name] }).to eq(['beta', 'alpha'])
+      expect(assigns(:top_mcas_math_concerns).map {|row| row[:name] }).to eq(['beta', 'alpha'])
+      expect(assigns(:top_mcas_ela_concerns).map {|row| row[:name] }).to eq(['beta', 'alpha'])
+    end
+  end
 end


### PR DESCRIPTION
What's new?

A minimal "at-risk classrooms" page, for identifying the classrooms that have students most in need of support, in terms of MCAS scores, absences and tardies.  This is just a starting point, and essentially mirrors the "students at risk" page to start.  Links are added to the header for minimal navigation.

There are also two small unrelated changes.  First, changing the "back" link text on the student back to say which classroom it links to, and fixing a bug in the students association on the Educator model.

Classrooms view:
<img width="1041" alt="screen shot 2015-12-21 at 1 58 55 pm" src="https://cloud.githubusercontent.com/assets/1056957/11939325/588b66aa-a7ef-11e5-991c-2f73122a9f3f.png">

Navigation links:
<img width="1084" alt="screen shot 2015-12-21 at 2 32 35 pm" src="https://cloud.githubusercontent.com/assets/1056957/11939374/b3f71070-a7ef-11e5-88b8-785eb98d74bf.png">

Update link text, back to roster for particular classroom:
<img width="262" alt="screen shot 2015-12-21 at 1 46 44 pm" src="https://cloud.githubusercontent.com/assets/1056957/11939333/6a8750f8-a7ef-11e5-8dbd-30560ff36526.png">