### PR TITLE
Cap number of classrooms returned on classroom risk page

### DIFF
--- a/app/assets/stylesheets/schools.css
+++ b/app/assets/stylesheets/schools.css
@@ -15,7 +15,12 @@
     background: $math;
   }
 
-  .attendance-section .dashboard-table {
+  .attendance-absences-concern .dashboard-table,
+  .attendance-tardies-concern .dashboard-table {
     background: $attendance;
+  }
+
+  .summary-container {
+    min-height: 288px;
   }
 }

--- a/app/controllers/schools_controller.rb
+++ b/app/controllers/schools_controller.rb
@@ -18,9 +18,10 @@ class SchoolsController < ApplicationController
     homerooms = @school.students.map(&:homeroom).compact.uniq
     homeroom_queries = HomeroomQueries.new(homerooms)
 
-    @top_absences = homeroom_queries.top_absences
-    @top_tardies = homeroom_queries.top_tardies
-    @top_mcas_math_concerns = homeroom_queries.top_mcas_math_concerns
-    @top_mcas_ela_concerns = homeroom_queries.top_mcas_ela_concerns
+    limit = 5
+    @top_absences = homeroom_queries.top_absences.first(limit)
+    @top_tardies = homeroom_queries.top_tardies.first(limit)
+    @top_mcas_math_concerns = homeroom_queries.top_mcas_math_concerns.first(limit)
+    @top_mcas_ela_concerns = homeroom_queries.top_mcas_ela_concerns.first(limit)
   end
 end

--- a/app/views/schools/homerooms.erb
+++ b/app/views/schools/homerooms.erb
@@ -4,24 +4,26 @@
   </div>
   <div class="detailed-content-area">
     <div class="left-panel">
-      <div class="mcas-math-concern">
+      <div class="mcas-math-concern summary-container">
         <h2>Math: MCAS</h2>
         <%= render "homeroom_table", homerooms: @top_mcas_math_concerns, header: 'Average Score' %>
       </div>
-      <div class="mcas-ela-concern">
+      <div class="mcas-ela-concern summary-container">
         <h2>ELA: MCAS</h2>
         <%= render "homeroom_table", homerooms: @top_mcas_ela_concerns, header: 'Average Score' %>
       </div>
       <p><em>Data reflect most recent available MCAS results.</em></p>
     </div>
     <div class="right-panel">
-      <div class="attendance-section">
+      <div class="attendance-absences-concern summary-container">
         <h2>Attendance: Absences</h2>
         <%= render "homeroom_table", homerooms: @top_absences, header: 'Average Absences per Student' %>
+      </div>
+      <div class="attendance-tardies-concern summary-container">
         <h2>Attendance: Tardies</h2>
         <%= render "homeroom_table", homerooms: @top_tardies, header: 'Average Tardies per Student' %>
-        <p><em>Data reflect absences and tardies during this current school year.</em></p>
       </div>
+      <p><em>Data reflect absences and tardies during this current school year.</em></p>
     </div>
   </div>
 </div>

--- a/app/views/schools/show.html.erb
+++ b/app/views/schools/show.html.erb
@@ -2,26 +2,28 @@
   <div class="topline-info underline">
     <h1>Students at Risk: <%= @school.name %></h1>
   </div>
-  <div class="detailed-content-area">
+  <div class="detailed-content-area summary-container">
     <div class="left-panel">
       <div class="mcas-math-concern">
         <h2>Math: MCAS</h2>
         <%= render "student_table", students: @top_mcas_math_concerns, header: 'Score' %>
       </div>
-      <div class="mcas-ela-concern">
+      <div class="mcas-ela-concern summary-container">
         <h2>ELA: MCAS</h2>
         <%= render "student_table", students: @top_mcas_ela_concerns, header: 'Score' %>
       </div>
       <p><em>Data reflect most recent available MCAS results.</em></p>
     </div>
     <div class="right-panel">
-      <div class="attendance-section">
+      <div class="attendance-absences-concern summary-container">
         <h2>Attendance: Absences</h2>
         <%= render "student_table", students: @top_absences, header: 'Absences' %>
+      </div>
+      <div class="attendance-tardies-concern summary-container">
         <h2>Attendance: Tardies</h2>
         <%= render "student_table", students: @top_tardies, header: 'Tardies' %>
-        <p><em>Data reflect absences and tardies during this current school year.</em></p>
       </div>
+      <p><em>Data reflect absences and tardies during this current school year.</em></p>
     </div>
   </div>
 </div>


### PR DESCRIPTION
This updates the controller results to cap the number of classrooms, and also fixes the min-height of the tables.

See production URL at https://somerville-teacher-tool.herokuapp.com/schools/2/homerooms to see tables not aligning and not capping results.

After:
<img width="989" alt="screen shot 2015-12-22 at 4 12 08 pm" src="https://cloud.githubusercontent.com/assets/1056957/11966008/d80677d0-a8c6-11e5-9283-b3af08d0b943.png">

<img width="1009" alt="screen shot 2015-12-22 at 4 12 14 pm" src="https://cloud.githubusercontent.com/assets/1056957/11966009/d938e23c-a8c6-11e5-8b64-f54d6ed77c96.png">
