### PR TITLE
Add custom intervention types

### DIFF
--- a/app/assets/javascripts/student/interventions_controller.js
+++ b/app/assets/javascripts/student/interventions_controller.js
@@ -1,9 +1,9 @@
 (function(root) {
 
   /*
-  This owns a piece of the DOM rendered by Rails.  It takes an initial list of `interventions` 
+  This owns a piece of the DOM rendered by Rails.  It takes an initial list of `interventions`
   and then owns that state and any changes to it over time.
-  
+
   This class expects a few Handlers templates to be available on the window.HandlebarsTemplates
   object.
 
@@ -19,7 +19,7 @@
   React component.  An exception is the forms that are rendered.  The state in the input elements
   is not preserved, so if a server error occurs saving the form, the error message are
   inserted into the DOM without a full render.
-  */  
+  */
   var InterventionsController = function (options) {
     this.initialize(options);
   };
@@ -68,6 +68,7 @@
       this.$el.on('click', '#add-new-intervention', this.onAddNewIntervention.bind(this));
       this.$el.on('click', '.cancel-new-intervention', this.onCancelNewIntervention.bind(this));
       this.$el.on('click', '.intervention-cell', this.onSelectedIntervention.bind(this));
+      this.$el.on('change', '#intervention_type_dropdown_select', this.onSelectCustomIntervention.bind(this));
       this.$el.on('ajax:success', '.new-intervention-form', this.onNewInterventionSaveSucceeded.bind(this));
       this.$el.on('ajax:error', '.new-intervention-form', this.onNewInterventionSaveFailed.bind(this));
 
@@ -106,6 +107,14 @@
       this.selectedInterventionId = this.defaultSelectedIntervention();
       this.isShowingNewIntervention = false;
       this.render();
+    },
+
+    onSelectCustomIntervention: function (e) {
+      var selected_options = e.target.selectedOptions;
+      var selected_name = $(selected_options).data('name');
+      if (selected_name === 'Other') {
+        this.renderCustomInterventionField();
+      }
     },
 
     onNewInterventionSaveSucceeded: function (e, data, status, xhr) {
@@ -202,6 +211,11 @@
         isAddingProgressNote: this.isAddingProgressNote,
         educators: this.options.educators
       });
+    },
+
+    renderCustomInterventionField: function () {
+      var html = this.renderTemplate('customInterventionField', {});
+      $('#custom_intervention_field').html(html);
     }
   });
 

--- a/app/assets/javascripts/student/interventions_controller.js
+++ b/app/assets/javascripts/student/interventions_controller.js
@@ -68,7 +68,7 @@
       this.$el.on('click', '#add-new-intervention', this.onAddNewIntervention.bind(this));
       this.$el.on('click', '.cancel-new-intervention', this.onCancelNewIntervention.bind(this));
       this.$el.on('click', '.intervention-cell', this.onSelectedIntervention.bind(this));
-      this.$el.on('change', '#intervention_type_dropdown_select', this.onSelectCustomIntervention.bind(this));
+      this.$el.on('change', '#intervention_type_dropdown_select', this.onSelectInterventionType.bind(this));
       this.$el.on('ajax:success', '.new-intervention-form', this.onNewInterventionSaveSucceeded.bind(this));
       this.$el.on('ajax:error', '.new-intervention-form', this.onNewInterventionSaveFailed.bind(this));
 
@@ -109,11 +109,13 @@
       this.render();
     },
 
-    onSelectCustomIntervention: function (e) {
+    onSelectInterventionType: function (e) {
       var selected_options = e.target.selectedOptions;
       var selected_name = $(selected_options).data('name');
       if (selected_name === 'Other') {
         this.renderCustomInterventionField();
+      } else {
+        this.removeCustomInterventionField();
       }
     },
 
@@ -216,7 +218,12 @@
     renderCustomInterventionField: function () {
       var html = this.renderTemplate('customInterventionField', {});
       $('#custom_intervention_field').html(html);
+    },
+
+    removeCustomInterventionField: function () {
+      $('#custom_intervention_field').text('');
     }
+
   });
 
   root.InterventionsController = InterventionsController;

--- a/app/assets/javascripts/student/interventions_controller_templates.hbs
+++ b/app/assets/javascripts/student/interventions_controller_templates.hbs
@@ -79,12 +79,15 @@
     <h1>Add Intervention</h1>
     <p class="alert field errors"></p>
     <label>Select Intervention</label>
-    <select name="intervention[intervention_type_id]" required="required">
+    <select id="intervention_type_dropdown_select"
+            name="intervention[intervention_type_id]"
+            required="required">
       <option value=""> -- Intervention type -- </option>
       {{#interventionTypes}}
-        <option value="{{id}}">{{name}}</option>
+        <option value="{{id}}" data-name="{{name}}">{{name}}</option>
       {{/interventionTypes}}
     </select>
+    <div id="custom_intervention_field"></div>
     <label>Comment</label>
     <textarea cols="40" name="intervention[comment]" placeholder="Add comment" rows="5"></textarea>
     <label>Goal</label>
@@ -119,3 +122,8 @@
     {{#errors}}<li>{{.}}</li>{{/errors}}
   </ul>
 {{/formErrors}}
+
+{{#customInterventionField}}
+  <label>Custom intervention name</label>
+  <input name="intervention[custom_intervention_name]">
+{{/customInterventionField}}

--- a/app/assets/stylesheets/buttons.scss
+++ b/app/assets/stylesheets/buttons.scss
@@ -16,8 +16,3 @@
     text-decoration: none;
   }
 }
-
-.cancel-btn, .save-btn {
-  float: right;
-  margin-left: 10px;
-}

--- a/app/controllers/interventions_controller.rb
+++ b/app/controllers/interventions_controller.rb
@@ -20,6 +20,7 @@ class InterventionsController < ApplicationController
       :student_id,
       :educator_id,
       :intervention_type_id,
+      :custom_intervention_name,
       :comment,
       :start_date,
       :end_date,

--- a/db/migrate/20151231193719_add_custom_intervention_name_to_intervention.rb
+++ b/db/migrate/20151231193719_add_custom_intervention_name_to_intervention.rb
@@ -1,0 +1,5 @@
+class AddCustomInterventionNameToIntervention < ActiveRecord::Migration
+  def change
+    add_column :interventions, :custom_intervention_name, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151218231639) do
+ActiveRecord::Schema.define(version: 20151231193719) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -132,6 +132,7 @@ ActiveRecord::Schema.define(version: 20151218231639) do
     t.integer  "school_year_id"
     t.text     "goal"
     t.integer  "student_school_year_id"
+    t.string   "custom_intervention_name"
   end
 
   create_table "progress_notes", force: true do |t|

--- a/spec/factories/interventions.rb
+++ b/spec/factories/interventions.rb
@@ -1,12 +1,19 @@
 FactoryGirl.define do
+
   factory :intervention do
     association :student
     association :intervention_type
     start_date Date.new(2014, 9, 9)
     number_of_hours 10
+
     trait :end_date do
       end_date Date.new(2014, 9, 12)
     end
+
+    trait :custom_intervention_name do
+      custom_intervention_name "More practice time!"
+    end
+
     factory :atp_intervention do
       association :intervention_type, name: "After-School Tutoring (ATP)"
       factory :more_recent_atp_intervention do
@@ -14,8 +21,10 @@ FactoryGirl.define do
         number_of_hours 11
       end
     end
-    factory :non_atp_intervention do
+
+    trait :non_atp_intervention do
       association :intervention_type, name: "Extra Dance "
     end
+
   end
 end

--- a/spec/factories/students.rb
+++ b/spec/factories/students.rb
@@ -183,7 +183,7 @@ FactoryGirl.define do
       end
       factory :student_with_one_non_atp_intervention do
         after(:create) do |student|
-          FactoryGirl.create(:non_atp_intervention, student: student)
+          FactoryGirl.create(:intervention, :non_atp_intervention, student: student)
         end
       end
       factory :student_with_multiple_atp_interventions do

--- a/spec/javascripts/student/interventions_controller_spec.js
+++ b/spec/javascripts/student/interventions_controller_spec.js
@@ -16,7 +16,8 @@ describe("InterventionsController", function() {
     interventionTypes: function() {
       return [
         { id: 4, name: 'After School Tutoring (ATP)' },
-        { id: 6, name: 'Math Tutor' }
+        { id: 6, name: 'Math Tutor' },
+        { id: 7, name: 'Other' }    // for testing custom intervention feature
       ];
     },
     intervention: function(options) {
@@ -86,7 +87,7 @@ describe("InterventionsController", function() {
       expect(helpers.findProgressNotes($el).length).toEqual(progressNotes.length);
       var progressNotesText = $el.find('.progress-notes-list').text();
       progressNotes.forEach(function(progressNote) {
-        expect(progressNotesText).toContain(progressNote.content);  
+        expect(progressNotesText).toContain(progressNote.content);
       });
     }
   };
@@ -177,6 +178,18 @@ describe("InterventionsController", function() {
 
       expect(helpers.findInterventionNames($el)).toEqual(['Math Tutor']);
       expect($el.find('form').length).toEqual(0);
+    });
+
+    xit('allows adding intervention with a custom intervention name', function() {
+      var controller = helpers.createController();
+      var $el = controller.render();
+      $el.find('.add-new-intervention').click();
+
+      $el.find('option[data-name="Other"]').prop('selected', 'selected');
+      $el.find('[name="intervention[intervention_type_id]"]').trigger('change');
+
+      expect($el.text()).toContain('Custom intervention name');
+      expect($el.html()).toContain('intervention[custom_intervention_name]');
     });
   });
 });

--- a/spec/models/intervention_spec.rb
+++ b/spec/models/intervention_spec.rb
@@ -2,6 +2,30 @@ require 'rails_helper'
 
 RSpec.describe Intervention, type: :model do
 
+  describe '#name' do
+    context 'has custom intervention name' do
+      let(:intervention) { FactoryGirl.create(:intervention, :custom_intervention_name) }
+      it 'shows the custom intervention name' do
+        expect(intervention.name).to eq 'More practice time!'
+      end
+    end
+    context 'does not have custom intervention name' do
+      context 'intervention type has name' do
+        let(:intervention) { FactoryGirl.create(:atp_intervention) }
+        it 'shows the intervention type name' do
+          expect(intervention.name).to eq 'After-School Tutoring (ATP)'
+        end
+      end
+
+      context 'intervention type does not have name' do
+        let(:intervention) { FactoryGirl.create(:intervention) }
+        it 'returns nil' do
+          expect(intervention.name).to eq nil
+        end
+      end
+    end
+  end
+
   describe '.with_start_and_end_dates' do
     context 'intervention with no end date' do
       let!(:intervention) { FactoryGirl.create(:intervention) }

--- a/spec/models/intervention_spec.rb
+++ b/spec/models/intervention_spec.rb
@@ -16,4 +16,21 @@ RSpec.describe Intervention, type: :model do
       end
     end
   end
+
+  describe '#cannot_have_both_intervention_type_and_custom_intervention_name' do
+    context 'has only an intervention type' do
+      let(:intervention) { FactoryGirl.build(:intervention) } # Minimal valid intervention includes an intervention_type association
+      it 'is valid' do
+        expect(intervention).to be_valid
+      end
+    end
+
+    context 'has both' do
+      let(:intervention) { FactoryGirl.build(:intervention, :custom_intervention_name) }
+      it 'is invalid' do
+        expect(intervention).to be_invalid
+      end
+    end
+  end
+
 end

--- a/spec/models/intervention_spec.rb
+++ b/spec/models/intervention_spec.rb
@@ -17,20 +17,4 @@ RSpec.describe Intervention, type: :model do
     end
   end
 
-  describe '#cannot_have_both_intervention_type_and_custom_intervention_name' do
-    context 'has only an intervention type' do
-      let(:intervention) { FactoryGirl.build(:intervention) } # Minimal valid intervention includes an intervention_type association
-      it 'is valid' do
-        expect(intervention).to be_valid
-      end
-    end
-
-    context 'has both' do
-      let(:intervention) { FactoryGirl.build(:intervention, :custom_intervention_name) }
-      it 'is invalid' do
-        expect(intervention).to be_invalid
-      end
-    end
-  end
-
 end


### PR DESCRIPTION
## What's the feature?

* Feature idea from @jsgeiser via email: 

_"For the intervention list, where it says "other", can we have a place to label that "other" intervention? I have been using that one a bit."_

## GIF

![custom-intervention-field](https://cloud.githubusercontent.com/assets/3209501/12075540/4765db1e-b152-11e5-91d8-a3e493ec1b2d.gif)