### PR TITLE
Fix bug with updating most_recent_star_math_percentile attribute

### DIFF
--- a/app/models/student.rb
+++ b/app/models/student.rb
@@ -83,7 +83,7 @@ class Student < ActiveRecord::Base
       most_recent_mcas_math_scaled: latest_mcas_math.scale_score,
       most_recent_mcas_ela_scaled: latest_mcas_ela.scale_score,
       most_recent_star_reading_percentile: latest_star_reading.percentile_rank,
-      most_recent_star_math_percentile: latest_mcas_math.percentile_rank
+      most_recent_star_math_percentile: latest_star_math.percentile_rank
     })
   end
 

--- a/spec/models/student_spec.rb
+++ b/spec/models/student_spec.rb
@@ -198,10 +198,11 @@ RSpec.describe Student do
 
   describe '#update_recent_student_assessments' do
     context 'has student assessments' do
-      let(:student) { FactoryGirl.create(:student_with_mcas_math_warning_assessment) }
+      let(:student) { FactoryGirl.create(:student_with_mcas_math_advanced_and_star_math_warning_assessments) }
       it 'sets correct attribute on the student' do
         student.update_recent_student_assessments
-        expect(student.reload.most_recent_mcas_math_performance).to eq 'W'
+        expect(student.reload.most_recent_mcas_math_performance).to eq 'A'
+        expect(student.reload.most_recent_star_math_percentile).to eq 8
       end
     end
   end


### PR DESCRIPTION
@alexsoble This was what we were seeing with the STAR math scores the other day.  I don't think it affects anything else, looks like the roster and profile pages access this data a different way.

The next `rake update:recent_assessments` run tomorrow should fix this, and I can verify that before Friday.