### PR TITLE
Revoke STAR importers' ability to create new students

### DIFF
--- a/app/importers/settings/somerville_settings.rb
+++ b/app/importers/settings/somerville_settings.rb
@@ -70,6 +70,10 @@ class Settings::SomervilleSettings
   end
 
   def configuration
+    # Important for X2 importers to come first since they are the sole source of truth about students.
+    # STAR importers don't import students, they only import STAR results.
+    # If STAR importers run first, they won't have students to update STAR results for (at least the first time around).
+
     return x2_importers + star_importers + local_importers if Rails.env.development?
     return x2_importers + star_importers
   end

--- a/app/importers/star_math_importer.rb
+++ b/app/importers/star_math_importer.rb
@@ -16,7 +16,9 @@ class StarMathImporter
 
   def import_row(row)
     date_taken = Date.strptime(row[:date_taken].split(' ')[0], "%m/%d/%Y")
-    student = Student.where(local_id: row[:local_id]).first_or_create!
+    student = Student.find_by_local_id(row[:local_id])
+
+    return if student.nil?
 
     star_assessment = StudentAssessment.where({
       student_id: student.id,

--- a/app/importers/star_reading_importer.rb
+++ b/app/importers/star_reading_importer.rb
@@ -16,7 +16,9 @@ class StarReadingImporter
 
   def import_row(row)
     date_taken = Date.strptime(row[:date_taken].split(' ')[0], "%m/%d/%Y")
-    student = Student.where(local_id: row[:local_id]).first_or_create!
+    student = Student.find_by_local_id(row[:local_id])
+
+    return if student.nil?
 
     star_assessment = StudentAssessment.where({
       student_id: student.id,

--- a/spec/importers/star_math_importer_spec.rb
+++ b/spec/importers/star_math_importer_spec.rb
@@ -7,37 +7,44 @@ RSpec.describe StarMathImporter do
       let(:transformer) { StarMathCsvTransformer.new }
       let(:csv) { transformer.transform(file) }
       let(:math_importer) { StarMathImporter.new }
+
       context 'with good data' do
-        it 'creates a new student assessment' do
-          expect { math_importer.import(csv) }.to change { StudentAssessment.count }.by 1
-        end
-        it 'creates a new STAR MATH assessment' do
-          math_importer.import(csv)
-          student_assessment = StudentAssessment.last
-          assessment = student_assessment.assessment
-          expect(assessment.family).to eq "STAR"
-          expect(assessment.subject).to eq "Math"
-        end
-        it 'sets math percentile rank correctly' do
-          math_importer.import(csv)
-          expect(StudentAssessment.last.percentile_rank).to eq 70
-        end
-        it 'sets date taken correctly' do
-          math_importer.import(csv)
-          expect(StudentAssessment.last.date_taken).to eq Date.new(2015, 1, 21)
-        end
+
         context 'existing student' do
           let!(:student) { FactoryGirl.create(:student_we_want_to_update) }
+          it 'creates a new student assessment' do
+            expect { math_importer.import(csv) }.to change { StudentAssessment.count }.by 1
+          end
+          it 'creates a new STAR MATH assessment' do
+            math_importer.import(csv)
+            student_assessment = StudentAssessment.last
+            assessment = student_assessment.assessment
+            expect(assessment.family).to eq "STAR"
+            expect(assessment.subject).to eq "Math"
+          end
+          it 'sets math percentile rank correctly' do
+            math_importer.import(csv)
+            expect(StudentAssessment.last.percentile_rank).to eq 70
+          end
+          it 'sets date taken correctly' do
+            math_importer.import(csv)
+            expect(StudentAssessment.last.date_taken).to eq Date.new(2015, 1, 21)
+          end
           it 'does not create a new student' do
             expect { math_importer.import(csv) }.to change(Student, :count).by 0
           end
         end
-        context 'new student' do
-          it 'creates a new student object' do
-            expect { math_importer.import(csv) }.to change(Student, :count).by 1
+
+        context 'student does not exist' do
+          it 'does not create a new student assessment' do
+            expect { math_importer.import(csv) }.to change { StudentAssessment.count }.by 0
+          end
+          it 'does not create a new student' do
+            expect { math_importer.import(csv) }.to change(Student, :count).by 0
           end
         end
       end
+
       context 'with bad data' do
         let(:file) { File.open("#{Rails.root}/spec/fixtures/bad_star_reading_data.csv") }
         let(:transformer) { StarMathCsvTransformer.new }

--- a/spec/importers/star_reading_importer_spec.rb
+++ b/spec/importers/star_reading_importer_spec.rb
@@ -7,33 +7,37 @@ RSpec.describe StarReadingImporter do
       let(:transformer) { StarReadingCsvTransformer.new }
       let(:csv) { transformer.transform(file) }
       let(:reading_importer) { StarReadingImporter.new }
+
       context 'with good data' do
-        it 'creates a new student assessment' do
-          expect { reading_importer.import(csv) }.to change { StudentAssessment.count }.by 1
-        end
-        it 'creates a new STAR Reading assessment' do
-          reading_importer.import(csv)
-          student_assessment = StudentAssessment.last
-          expect(student_assessment.family).to eq "STAR"
-          expect(student_assessment.subject).to eq "Reading"
-        end
-        it 'sets instructional reading level correctly' do
-          reading_importer.import(csv)
-          expect(StudentAssessment.last.instructional_reading_level).to eq 5.0
-        end
-        it 'sets date taken correctly' do
-          reading_importer.import(csv)
-          expect(StudentAssessment.last.date_taken).to eq Date.new(2015, 1, 21)
-        end
         context 'existing student' do
           let!(:student) { FactoryGirl.create(:student_we_want_to_update) }
+          it 'creates a new student assessment' do
+            expect { reading_importer.import(csv) }.to change { StudentAssessment.count }.by 1
+          end
+          it 'creates a new STAR Reading assessment' do
+            reading_importer.import(csv)
+            student_assessment = StudentAssessment.last
+            expect(student_assessment.family).to eq "STAR"
+            expect(student_assessment.subject).to eq "Reading"
+          end
+          it 'sets instructional reading level correctly' do
+            reading_importer.import(csv)
+            expect(StudentAssessment.last.instructional_reading_level).to eq 5.0
+          end
+          it 'sets date taken correctly' do
+            reading_importer.import(csv)
+            expect(StudentAssessment.last.date_taken).to eq Date.new(2015, 1, 21)
+          end
           it 'does not create a new student' do
             expect { reading_importer.import(csv) }.to change(Student, :count).by 0
           end
         end
-        context 'new student' do
-          it 'creates a new student object' do
-            expect { reading_importer.import(csv) }.to change(Student, :count).by 1
+        context 'student does not exist' do
+          it 'does not create a new student assessment' do
+            expect { reading_importer.import(csv) }.to change { StudentAssessment.count }.by 0
+          end
+          it 'does not create a new student' do
+            expect { reading_importer.import(csv) }.to change(Student, :count).by 0
           end
         end
       end


### PR DESCRIPTION
## Notes

+ STAR's historical file can conflict in some ways with X2
+ As the SIS, X2 should be the sole source of truth about students
+ For example, the STAR historical file doesn't know whether students are active or inactive in Somerville Public Schools
+ We don't want X2 to not import a student because they are active and then have STAR create a shell student object with no attributes besides STAR results