### PR TITLE
Use OR logic for school overview filters within the same category

### DIFF
--- a/app/assets/javascripts/components/school_overview_page.js
+++ b/app/assets/javascripts/components/school_overview_page.js
@@ -80,6 +80,14 @@
       return _.intersection.apply(this, studentArrays);
     },
 
+    getFilteredStudents: function() {
+      return this._filteredStudents;
+    },
+
+    setFilteredStudents: function(students) {
+      this._filteredStudents = students;
+    },
+
     filteredStudents: function() {
       // Filters are applied with OR logic within the same category; AND logic between categories.
       //
@@ -150,6 +158,8 @@
     },
 
     render: function() {
+      this.setFilteredStudents(this.filteredStudents());
+
       return dom.div({
         className: 'school-overview',
         style: { fontSize: styles.fontSize }
@@ -168,7 +178,7 @@
         dom.div({ className: 'list', style: { padding: 20 } },
           createEl(StudentsTable, {
             key: _.pluck(this.state.filters, 'identifier').join(','), // hack for tablesorter
-            students: this.filteredStudents()
+            students: this.getFilteredStudents()
           })
         )
       );
@@ -177,7 +187,7 @@
     renderSummary: function() {
       return dom.div({ className: 'summary', style: styles.summary },
         dom.div({ style: { backgroundColor: 'rgba(49, 119, 201, 0.75)', color: 'white', display: 'inline-block', width: '12em', padding: 5 } },
-          'Found: ' + this.filteredStudents().length + ' students'
+          'Found: ' + this.getFilteredStudents().length + ' students'
         ),
         dom.a({
           style: {
@@ -201,7 +211,7 @@
     },
 
     renderDownloadLink: function() {
-      var students = this.filteredStudents();
+      var students = this.getFilteredStudents();
       var header = [
         'First Name',
         'Last Name',
@@ -371,7 +381,7 @@
     },
 
     createItem: function(caption, filter) {
-      var students = this.filteredStudents();
+      var students = this.getFilteredStudents();
       return {
         caption: caption,
         percentage: (students.length === 0) ? 0 : students.filter(filter.filterFn).length / students.length,

--- a/app/assets/javascripts/components/school_overview_page.js
+++ b/app/assets/javascripts/components/school_overview_page.js
@@ -34,10 +34,97 @@
       window.history.pushState({}, null, this.filtersHash());
     },
 
+    filterKey: function (filter) {
+      return filter.key;
+    },
+
+    activeFiltersByCategory: function () {
+      // Group by active filters by category.
+      // Returns an array of arrays; each inner array is a group of filters with the same category.
+
+      return _.values(_.groupBy(this.state.filters, this.filterKey));
+    },
+
+    filterWithOr: function (filterGroups) {
+      // Expects an array of arrays as input; each inner array is a group of filters to be reduced with OR logic.
+      //
+      // Outputs another array of arrays; now, each inner array is an array of students reduced with OR logic.
+      //
+      // The next function will reduce those students down with AND logic.
+      //
+      // Example:
+      //
+      //   input ~> [
+      //     [{FILTER:students_in_8th_grade}, {FILTER:students_in_7th_grade}],
+      //     [{FILTER:students_with_high_math_scores}]
+      //   ]
+      //
+      //   output ~> [
+      //      [students_in_7th_or_8th_grade],
+      //      [students_with_high_math_scores]
+      //   ]
+
+      var allStudents = this.props.allStudents;
+      return filterGroups.map(function(filterGroup) {
+        return filterGroup.reduce(function(filteredStudents, filter) {
+          return _.uniq(filteredStudents.concat(allStudents.filter(filter.filterFn)));
+        }, []);
+      });
+    },
+
+    filterWithAnd: function (studentArrays) {
+      // Expects an array of arrays as input.
+      // Each inner array represents a group of students that has been reduced with OR logic.
+      // Outputs a single array of all students at the intersection of the arrays (AND logic).
+
+      return _.intersection.apply(this, studentArrays);
+    },
+
     filteredStudents: function() {
-      return this.state.filters.reduce(function(filteredStudents, filter) {
-        return filteredStudents.filter(filter.filterFn);
-      }, this.props.allStudents);
+      // Filters are applied with OR logic within the same category; AND logic between categories.
+      //
+      // For example: "Students in 7th OR 8th grade AND with an advanced math score."
+      //
+      // There are five major filter states to handle:
+      //
+      // 1. No filters
+      // 2. One filter                                      (no need to consider AND versus OR)
+      // 3. Multiple filters within same category           (all OR)
+      // 4. Multiple filters all different categories       (all AND)
+      // 5. Multiple filters within and between categories  (OR plus AND)
+
+      // Case 1, no filters:
+      if (this.state.filters.length === 0) return this.props.allStudents;
+
+      // Case 2, one filter:
+      if (this.state.filters.length === 1) {
+        return this.props.allStudents.filter(this.state.filters[0].filterFn);
+      }
+
+      // More than one filter, let's group the filters by category
+      var activeFiltersByCategory = this.activeFiltersByCategory();
+
+      // Filter students using OR logic within each category
+      var studentsOrFiltered = this.filterWithOr.call(this, activeFiltersByCategory);
+
+      // Case 3, all fiters within same category:
+      // Return all of the students that have been filtered with OR logic
+      if (activeFiltersByCategory.length === 1) return studentsOrFiltered[0];
+
+      // Are there categories with more than one filter in them?
+      var maxFiltersPerCategory = _.max(activeFiltersByCategory.map(function(category) {
+        return category.length;
+      }));
+
+      // Case 4, multiple filters but all different categories:
+      if (maxFiltersPerCategory === 1) {
+        return this.state.filters.reduce(function(filteredStudents, filter) {
+          return filteredStudents.filter(filter.filterFn);
+        }, this.props.allStudents);
+      }
+
+      // Case 5, multiple filters within and between categories:
+      return this.filterWithAnd.call(this, studentsOrFiltered);
     },
 
     clearFilters: function() {
@@ -519,7 +606,8 @@
         filterFn: function(student) {
           var value = student[key];
           return (_.isNumber(value) && value >= range[0] && value < range[1]);
-        }
+        },
+        key: key
       };
     },
     // Types are loose, since this is serialized from the hash
@@ -528,7 +616,8 @@
         identifier: ['equal', key, value].join(':'),
         filterFn: function(student) {
           return (student[key] == value);
-        }
+        },
+        key: key
       };
     },
     Null: function(key) {
@@ -537,7 +626,8 @@
         filterFn: function(student) {
           var value = student[key];
           return (value === null || value === undefined) ? true : false;
-        }
+        },
+        key: key
       };
     },
     InterventionType: function(interventionTypeId) {
@@ -548,7 +638,8 @@
           return student.interventions.filter(function(intervention) {
             return intervention.intervention_type_id === interventionTypeId;
           }).length > 0;
-        }
+        },
+        key: 'intervention_type'
       };
     },
     YearsEnrolled: function(value) {
@@ -556,7 +647,8 @@
         identifier: ['years_enrolled', value].join(':'),
         filterFn: function(student) {
           return (calculateYearsEnrolled(student.registration_date) === value);
-        }
+        },
+        key: 'years_enrolled'
       };
     },
 

--- a/app/assets/javascripts/components/school_overview_page.js
+++ b/app/assets/javascripts/components/school_overview_page.js
@@ -86,6 +86,23 @@
 
     setFilteredStudents: function(students) {
       this._filteredStudents = students;
+      this.addToCache(students);
+    },
+
+    activeFiltersIdentifier: function () {
+      // Something like this: 'equal:grade:5-equal:program_assigned:2Way English'
+
+      return this.state.filters.map(function(filter) { return filter.identifier; }).join('-');
+    },
+
+    addToCache: function (students) {
+      if (this._filterCache === undefined) this._filterCache = {};
+      this._filterCache[this.activeFiltersIdentifier()] = students;
+    },
+
+    checkCache: function () {
+      if (this._filterCache === undefined) return;
+      return this._filterCache[this.activeFiltersIdentifier()];
     },
 
     filteredStudents: function() {
@@ -103,6 +120,9 @@
 
       // Case 1, no filters:
       if (this.state.filters.length === 0) return this.props.allStudents;
+
+      // Now there's some complexity. Let's check our client-side cache.
+      if (this.checkCache() !== undefined) return this.checkCache();
 
       // Case 2, one filter:
       if (this.state.filters.length === 1) {

--- a/spec/javascripts/components/school_overview_page_spec.js
+++ b/spec/javascripts/components/school_overview_page_spec.js
@@ -1,5 +1,86 @@
 describe('SchoolOverviewPage', function() {
 
+  // FILTERING FUNCTIONS //
+
+  describe('#filterWithOr', function() {
+    beforeEach(function() {
+
+      this.mari = { name: 'Mari', classroom: '101' }    // stubby student object
+      this.mark = { name: 'Mark', classroom: '101' }    // stubby student object
+      this.marv = { name: 'Marv', classroom: '102' }    // stubby student object
+
+      // Test filters
+      this.MariFilter = Filters.Equal('name', 'Mari');
+      this.MarkFilter = Filters.Equal('name', 'Mark');
+      this.Classroom101Filter = Filters.Equal('classroom', '101');
+      this.Classroom102Filter = Filters.Equal('classroom', '102');
+
+      this.page = new SchoolOverviewPage({
+        initialFilters: [],
+        allStudents: [this.mark, this.mari, this.marv]
+      });
+    });
+
+    describe('with filters that overlap', function() {
+      it('reduces each array to the set students that match either filter with no duplicates', function() {
+        var filters  = [[this.MariFilter, this.Classroom101Filter], [this.MarkFilter]];
+        var result = this.page.filterWithOr(filters);
+        expect(result).toEqual([
+          [this.mari, this.mark], [this.mark]
+        ]);
+      });
+    });
+
+    describe('with one filter', function() {
+      it('returns an array of students that match the fitler inside another array', function() {
+        var filters = [[this.Classroom101Filter]];
+        var result = this.page.filterWithOr(filters);
+        expect(result).toEqual([
+          [this.mark, this.mari]
+        ]);
+      });
+    });
+
+    describe('with an empty array', function() {
+      it('returns an empty array', function() {
+        var filters = [];
+        var result = this.page.filterWithOr(filters);
+        expect(result).toEqual([]);
+      });
+    });
+
+  });
+
+  describe('#filterWithAnd', function() {
+    beforeEach(function() {
+      this.page = new SchoolOverviewPage({initialFilters: []});
+      this.mari = { name: 'Mari' }    // stubby student object
+      this.mark = { name: 'Mark' }    // stubby student object
+    });
+
+    describe('with array of two arrays of students that intersect', function() {
+      it('returns an array of the intersection', function() {
+        var studentArrays = [[this.mari, this.mark], [this.mari]];
+        expect(this.page.filterWithAnd(studentArrays)).toEqual([this.mari]);
+      });
+    });
+
+    describe('with array of one array of students', function() {
+      it('returns the array with one less level of nesting', function() {
+        var studentArrays = [[this.mari]];
+        expect(this.page.filterWithAnd(studentArrays)).toEqual([this.mari]);
+      });
+    });
+
+    describe('with an empty array', function() {
+      it('returns an empty array', function() {
+        var studentArrays = [];
+        expect(this.page.filterWithAnd(studentArrays)).toEqual([]);
+      });
+    });
+
+  });
+
   // CACHING FUNCTIONS //
 
   describe('with one initial filter', function() {

--- a/spec/javascripts/components/school_overview_page_spec.js
+++ b/spec/javascripts/components/school_overview_page_spec.js
@@ -1,0 +1,36 @@
+describe('SchoolOverviewPage', function() {
+
+  // CACHING FUNCTIONS //
+
+  describe('with one initial filter', function() {
+
+    beforeEach(function() {
+      var TestFilter = Filters.Equal('height', 'short');
+      this.page = new SchoolOverviewPage({initialFilters: [TestFilter]});
+    });
+
+    describe('#activeFiltersIdentifier', function() {
+      it('sets the correct identifier', function() {
+        expect(this.page.activeFiltersIdentifier()).toEqual('equal:height:short');
+      });
+    });
+
+    describe('#checkCache with empty cache', function() {
+      it('is undefined', function () {
+        expect(this.page.checkCache()).toEqual(undefined);
+      });
+    });
+
+    describe('#checkCache when students have been added', function() {
+      it('returns the correct students', function() {
+        var students = [{ name: 'Jaime' }, { name: 'Jin' }, { name: 'Jack'}];
+        this.page.addToCache(students);
+        var cache = this.page.checkCache();
+        expect(cache.length).toEqual(3);
+        expect(cache[0].name).toEqual('Jaime');
+      });
+    });
+
+  });
+
+});


### PR DESCRIPTION
## What's new?

@jsgeiser said it best:

> "One question – when I click on multiple filter under one category, it won’t recognize that. (e.g. clicking on Free lunch and reduced lunch). Is there a way to click on more than one filter in a category?"

Allow Jill and other administrators to set filters that show students using OR combinations. 

For example: `Free lunch OR Reduced lunch AND Advanced math`

Also speed up performance: https://github.com/codeforamerica/somerville-teacher-tool/issues/383#issuecomment-173970574