### PR TITLE
Update seed InterventionTypes to match production, split out DevelopmentFixtures

### DIFF
--- a/app/assets/javascripts/school/star_reading_page.js
+++ b/app/assets/javascripts/school/star_reading_page.js
@@ -123,7 +123,7 @@ $(function() {
 
       render: function() {
         var sizing = { width: 300, height: 250 };
-        return dom.div({ style: { padding: 10, paddingBottom: 20 } },
+        return dom.div({ className: 'StarReadingOverviewPage', style: { paddingBottom: 20 } },
           dom.div({ className: 'header', style: styles.header }, createEl(SlicePanels, {
             allStudents: this.props.students,
             students: this.filteredStudents(),
@@ -446,7 +446,7 @@ $(function() {
           return this.clamp(bucketDomain, Math.floor(result.delta / bucketSize) * bucketSize);
         }, this));
         var maxCount = d3.max(buckets, function(bucket) { return bucket[1].length; });
-        var median = d3.median(_.pluck(studentsWithDeltas, 'delta'));
+        var median = d3.median(_.pluck(studentsWithDeltas, 'delta')) || 0;
 
         var x = d3.time.scale().domain(bucketDomain).range([0, width]);
         var barHeight = d3.scale.linear().domain([0, maxCount]).range([0, height]);

--- a/app/controllers/schools_controller.rb
+++ b/app/controllers/schools_controller.rb
@@ -3,12 +3,16 @@ class SchoolsController < ApplicationController
   before_action :authenticate_admin!      # Defined in ApplicationController.
 
   def show
+    use_fixtures = false
+    students = if use_fixtures then DevelopmentFixtures.new.students_show else Student.serialized_data end
+
     @serialized_data = {
-      students: Student.serialized_data,
+      students: students,
       intervention_types: InterventionType.all
     }
   end
 
+  # TODO(kr) deprecated
   def students
     @school = School.friendly.find(params[:id])
     attendance_queries = AttendanceQueries.new(@school)
@@ -24,56 +28,33 @@ class SchoolsController < ApplicationController
   # copy body of controller code into Rails console, run the code in the body of this method,
   # print it as JSON and then save it in the /data/schools/star_reading
   def star_reading
-    use_fixtures = false      # Toggle between using demo development data
-                              # and real data loaded in as a JSON fixture
-    time_now = Time.now
+    # Toggle between using demo development data and real data loaded in as a JSON fixture
+    use_fixtures = false
+    students_with_star_reading = if use_fixtures then DevelopmentFixtures.new.students_star_reading else students_with_star_reading() end
+
     @serialized_data = {
-      :students_with_star_reading => students_with_star_reading(time_now, false),
+      :students_with_star_reading => students_with_star_reading,
       :intervention_types => InterventionType.all
     }
   end
 
   private
-
-  def students_with_star_reading(time_now, use_fixtures)
-    return IO.read("#{Rails.root}/data/students_with_star_reading.json") if use_fixtures
-
-    sliceable_student_hashes(time_now, Student.all.includes(:assessments)) do |student|
+  def students_with_star_reading
+    sliceable_student_hashes(Student.all.includes(:assessments)) do |student|
       student.as_json.merge(star_reading_results: student.star_reading_results.as_json)
     end
   end
 
-  def overview_student_hashes(time_now)
-    sliceable_student_hashes(time_now, Student.all)
-  end
-
-
-  def current_school_year
-    DateToSchoolYear.new(Time.new).convert
-  end
-
-  def sliceable_student_hashes(time_now, students_assoc)
+  def sliceable_student_hashes(students_assoc)
     # Takes a lazy collection that has any eager includes needed, and yields each `student`
     # to a block that returns a hash representation of the student and data from the eager
     # includes.
-    current_school_year = DateToSchoolYear.new(time_now).convert
-    students_assoc.includes(:interventions, :discipline_incidents).map do |student|
+    students_assoc.includes(:interventions).map do |student|
       yield(student).merge({
         :interventions => student.interventions.as_json,
         :student_risk_level => student.student_risk_level.as_json,
-        :discipline_incidents_count => student.discipline_incidents.select do |incident|
-          incident.school_year == current_school_year
-        end.size
+        :discipline_incidents_count => student.most_recent_school_year.discipline_incidents.count
       })
     end
   end
-
-  # remove sensitive-ish fields
-  def clean_student_hash(student_hash)
-    student_hash.except(:address).merge({
-      first_name: ["Aladdin", "Chip", "Daisy", "Mickey", "Minnie", "Donald", "Elsa", "Mowgli", "Olaf", "Pluto", "Pocahontas", "Rapunzel", "Snow", "Winnie"].sample,
-      last_name: ["Disney", "Duck", "Kenobi", "Mouse", "Pan", "Poppins", "Skywalker", "White"].sample
-    })
-  end
-
 end

--- a/app/models/intervention_type.rb
+++ b/app/models/intervention_type.rb
@@ -1,34 +1,38 @@
 class InterventionType < ActiveRecord::Base
   has_many :interventions
 
+  # If this becomes out of sync with production, you can 
+  # generate this with:
+  # `puts InterventionType.all.as_json.map {|i| i.except('created_at', 'updated_at') }`
   def self.seed_somerville_intervention_types
+    InterventionType.destroy_all
     InterventionType.create([
-      { name: "After-School Tutoring (ATP)" },
-      { name: "Attendance Officer" },
-      { name: "Attendance Contract" },
-      { name: "Behavior Contract" },
-      { name: "Behavior Plan" },
-      { name: "Boys & Girls Club" },
-      { name: "Classroom Academic Intervention" },
-      { name: "Classroom Behavior Intervention" },
-      { name: "Community Schools" },
-      { name: "Counseling: In-House" },
-      { name: "Counseling: Outside/Physician Referral" },
-      { name: "ER Referral (Mental Health)" },
-      { name: "Math Tutor" },
-      { name: "Mobile Crisis Referral" },
-      { name: "MTSS Referral" },
-      { name: "OT/PT Consult" },
-      { name: "Parent Communication" },
-      { name: "Parent Conference/Meeting" },
-      { name: "Peer Mediation" },
-      { name: "Reading Specialist" },
-      { name: "Reading Tutor" },
-      { name: "SST Referral" },
-      { name: "Weekly Call/Email Home" },
-      { name: "X Block Tutor" },
-      { name: "51a Filing" },
-      { name: "Other" }
+      { id: 20, name: "After-School Tutoring (ATP)" },
+      { id: 21, name: "Attendance Officer" },
+      { id: 22, name: "Attendance Contract" },
+      { id: 23, name: "Behavior Contract" },
+      { id: 24, name: "Behavior Plan" },
+      { id: 25, name: "Boys & Girls Club" },
+      { id: 26, name: "Classroom Academic Intervention" },
+      { id: 27, name: "Classroom Behavior Intervention" },
+      { id: 28, name: "Community Schools" },
+      { id: 29, name: "Counseling: In-House" },
+      { id: 30, name: "Counseling: Outside/Physician Referral" },
+      { id: 31, name: "ER Referral (Mental Health)" },
+      { id: 32, name: "Math Tutor" },
+      { id: 33, name: "Mobile Crisis Referral" },
+      { id: 34, name: "MTSS Referral" },
+      { id: 35, name: "OT/PT Consult" },
+      { id: 36, name: "Parent Communication" },
+      { id: 37, name: "Parent Conference/Meeting" },
+      { id: 39, name: "Peer Mediation" },
+      { id: 40, name: "Reading Specialist" },
+      { id: 41, name: "Reading Tutor" },
+      { id: 42, name: "SST Referral" },
+      { id: 43, name: "Weekly Call/Email Home" },
+      { id: 44, name: "X Block Tutor" },
+      { id: 45, name: "51a Filing" },
+      { id: 46, name: "Other "}
     ])
   end
 

--- a/lib/development_fixtures.rb
+++ b/lib/development_fixtures.rb
@@ -1,0 +1,30 @@
+# This provides methods for reading in fixture data for specific controller endpoints,
+# which can be useful when prototyping new features where distributions in development data
+# don't match production data.
+class DevelopmentFixtures
+  def students_show
+    JSON.parse(IO.read("#{Rails.root}/data/cleaned_all_ss.json")).map do |student|
+      clean_student_hash student
+    end
+  end
+
+  def students_star_reading
+    return parse_fixture('students_with_star_reading.json').map do |student|
+      clean_student_hash student
+    end
+  end
+
+  private
+  def parse_fixture(relative_path)
+    fixture_filename = "#{Rails.root}/data/#{relative_path}"
+    JSON.parse(IO.read(fixture_filename))
+  end
+
+  # remove sensitive-ish fields
+  def clean_student_hash(student_hash)
+    student_hash.except(:address).merge({
+      first_name: ["Aladdin", "Chip", "Daisy", "Mickey", "Minnie", "Donald", "Elsa", "Mowgli", "Olaf", "Pluto", "Pocahontas", "Rapunzel", "Snow", "Winnie"].sample,
+      last_name: ["Disney", "Duck", "Kenobi", "Mouse", "Pan", "Poppins", "Skywalker", "White"].sample
+    })
+  end
+end

--- a/spec/controllers/bulk_intervention_assignments_controller_spec.rb
+++ b/spec/controllers/bulk_intervention_assignments_controller_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe BulkInterventionAssignmentsController, type: :controller do
   def create_valid_bulk_assignment_params
     {
       student_ids: [FactoryGirl.create(:student).id],
-      intervention_type_id: '1',
+      intervention_type_id: InterventionType.first.id,
       comment: 'Useful comment!',
       end_date: '2020/1/1',
       educator_id: '1'
@@ -33,7 +33,7 @@ RSpec.describe BulkInterventionAssignmentsController, type: :controller do
           let(:params) {
             { bulk_intervention_assignment: {
               student_ids: [student.id],
-              intervention_type_id: '1',
+              intervention_type_id: InterventionType.first.id,
               comment: 'Useful comment!',
               end_date: '2020/1/1',
               educator_id: '1' }
@@ -53,7 +53,7 @@ RSpec.describe BulkInterventionAssignmentsController, type: :controller do
           let(:params) {
             { bulk_intervention_assignment: {
               student_ids: [student.id, other_student.id],
-              intervention_type_id: '1',
+              intervention_type_id: InterventionType.first.id,
               end_date: '2020/1/1',
               educator_id: '1',
               goal: 'Fix the situation.' }
@@ -101,7 +101,7 @@ RSpec.describe BulkInterventionAssignmentsController, type: :controller do
             let(:params) { {
               bulk_intervention_assignment: {
                 student_ids: [1, "Q"],
-                intervention_type_id: '1' }
+                intervention_type_id: InterventionType.first.id }
               }
             }
             it 'returns a detailed error message' do

--- a/spec/controllers/interventions_controller_spec.rb
+++ b/spec/controllers/interventions_controller_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe InterventionsController, type: :controller do
         {
           educator_id: educator.id,
           student_id: student.id,
-          intervention_type_id: 1,
+          intervention_type_id: InterventionType.first.id,
           start_date: '2015/1/1',
           end_date: '2020/6/6'
         }

--- a/spec/factories/interventions.rb
+++ b/spec/factories/interventions.rb
@@ -23,7 +23,7 @@ FactoryGirl.define do
     end
 
     trait :non_atp_intervention do
-      intervention_type { InterventionType.find_by_name('Extra Dance') }
+      intervention_type { InterventionType.find_by_name('Attendance Contract') }
     end
 
   end

--- a/spec/factories/interventions.rb
+++ b/spec/factories/interventions.rb
@@ -15,7 +15,7 @@ FactoryGirl.define do
     end
 
     factory :atp_intervention do
-      association :intervention_type, name: "After-School Tutoring (ATP)"
+      intervention_type { InterventionType.find_by_name('After-School Tutoring (ATP)') }
       factory :more_recent_atp_intervention do
         start_date Date.new(2015, 9, 9)
         number_of_hours 11
@@ -23,7 +23,7 @@ FactoryGirl.define do
     end
 
     trait :non_atp_intervention do
-      association :intervention_type, name: "Extra Dance "
+      intervention_type { InterventionType.find_by_name('Extra Dance') }
     end
 
   end


### PR DESCRIPTION
I ran into problems trying to use fixture data, where the InterventionTypes seeded for development don't match production.  So this updates the seed method to use the same values in production.  There were a few specs that relied on specific `intervention_type_ids`, so it required updating those as well.

There's also some methods in `schools_controller` that weren't necessary anymore, so that was cleaned out as well as an update to take advantage of the new `student.most_recent_school_year.discipline_incidents.count`.

Finally, a small visual change to remove padding around the filters that was in the STAR data page and not the school overview page.
