### PR TITLE
Increase Unicorn timeout for prototyping new features shipped dark

### DIFF
--- a/config/unicorn.rb
+++ b/config/unicorn.rb
@@ -1,5 +1,5 @@
 worker_processes Integer(ENV["WEB_CONCURRENCY"] || 3)
-timeout 15
+timeout 30
 preload_app true
 
 before_fork do |server, worker|


### PR DESCRIPTION
We've been prototyping some new features that are using inefficient Rails queries (e.g., on STAR reading visualizations), and we'd like to defer optimizing them for a few more days.  This PR increases the Unicorn timeout to address occasional 500s, which based on these log messages are from Heroku timing out waiting for the Rails app:

```
2016-01-28T20:19:27.179750+00:00 heroku[router]: at=error code=H13 desc="Connection closed without response" method=GET path="/schools/hea/star_reading" host=somerville-teacher-tool.herokuapp.com request_id=5f1e0a10-f332-4ed4-b531-dbdad7b8f381 fwd="207.172.212.174" dyno=web.1 connect=0ms service=15813ms status=503 bytes=0
```