### PR TITLE
Optimize query in star_reading endpoint, fixing timeouts

### DIFF
--- a/spec/controllers/schools_controller_spec.rb
+++ b/spec/controllers/schools_controller_spec.rb
@@ -29,17 +29,14 @@ describe SchoolsController, :type => :controller do
     end
   end
 
-  describe '#fat_student_hashes' do
+  describe '#fat_student_hash' do
     let!(:student) { FactoryGirl.create(:student) }
     before { FactoryGirl.create(:student_school_year, student: student) }
-    let!(:student_hashes) { controller.send(:fat_student_hashes, Student.all) }
+    let!(:student_hash) { controller.send(:fat_student_hash, student) }
 
     context 'no events or student attributes' do
-      it 'has one student' do
-        expect(student_hashes.length).to eq(1)
-      end
       it 'includes nil student attributes' do
-        expect(student_hashes.first).to include({
+        expect(student_hash).to include({
          "disability" => nil,
          "first_name" => nil,
          "free_reduced_lunch" => nil,
@@ -68,23 +65,23 @@ describe SchoolsController, :type => :controller do
         })
       end
       it 'returns student_risk_level' do
-        expect(student_hashes.first[:student_risk_level].keys.length).to be > 0
+        expect(student_hash[:student_risk_level]).should_not be_nil
       end
       it 'returns an empty array of interventions' do
-        expect(student_hashes.first[:interventions]).to eq []
+        expect(student_hash[:interventions]).to eq []
       end
       it 'returns a discipline incident count of zero' do
-        expect(student_hashes.first[:discipline_incidents_count]).to eq 0
+        expect(student_hash[:discipline_incidents_count]).to eq 0
       end
     end
 
     context 'with interventions' do
       let!(:student) { FactoryGirl.create(:student_with_one_atp_intervention) }
       it 'returns 1 intervention' do
-        expect(student_hashes.first[:interventions].size).to eq 1
+        expect(student_hash[:interventions].size).to eq 1
       end
       it 'returns correct intervention data' do
-        expect(student_hashes.first[:interventions][0]).to include({
+        expect(student_hash[:interventions][0].as_json).to include({
           "student_id"=>student.id,
           "number_of_hours"=>10,
         })


### PR DESCRIPTION
This endpoint was timing out (over 30 seconds).  This makes some quick optimizations to includes some associations eagerly to get it reliably functional, although I think it'll still be worth adding a precompute task for this next week.

Benchmark.measure on the console showing times of [10, 17, 7, 9] seconds, so a noticeable enough improvement to ship and the revisit again.