### PR TITLE
Get simple educator permissions from X2

### DIFF
--- a/app/importers/educator_row.rb
+++ b/app/importers/educator_row.rb
@@ -12,6 +12,7 @@ class EducatorRow < Struct.new(:row)
       full_name: row[:full_name],
       staff_type: row[:staff_type],
       admin: is_admin?,
+      email: row[:login_name] + '@k12.somerville.ma.us',
       school_id: school_rails_id
     )
 

--- a/app/importers/educator_row.rb
+++ b/app/importers/educator_row.rb
@@ -1,0 +1,39 @@
+class EducatorRow < Struct.new(:row)
+
+  def self.build(row)
+    new(row).build
+  end
+
+  def build
+    educator = Educator.first_or_initialize(local_id: row[:local_id])
+
+    educator.assign_attributes(
+      state_id: row[:state_id],
+      full_name: row[:full_name],
+      staff_type: row[:staff_type],
+      admin: is_admin?,
+      school_id: school_rails_id
+    )
+
+    return educator
+  end
+
+  private
+
+  def is_admin?
+    row[:staff_type].present? && row[:staff_type] == "Administrator"
+  end
+
+  def school_local_id
+    row[:school_local_id]
+  end
+
+  def school_rails_id
+    school_ids_dictionary[school_local_id] if school_local_id.present?
+  end
+
+  def school_ids_dictionary
+    SchoolLocalIdToAppId.instance.ids_dictionary
+  end
+
+end

--- a/app/importers/educator_row.rb
+++ b/app/importers/educator_row.rb
@@ -5,7 +5,7 @@ class EducatorRow < Struct.new(:row)
   end
 
   def build
-    educator = Educator.first_or_initialize(local_id: row[:local_id])
+    educator = Educator.find_or_initialize_by(local_id: row[:local_id])
 
     educator.assign_attributes(
       state_id: row[:state_id],

--- a/app/importers/educators_importer.rb
+++ b/app/importers/educators_importer.rb
@@ -13,9 +13,12 @@ class EducatorsImporter
   end
 
   def import_row(row)
-    educator = EducatorRow.build(row)
-    educator.save!
     homeroom = Homeroom.find_by_name!(row[:homeroom]) if row[:homeroom].present?
+    educator = EducatorRow.build(row)
+
+    return unless homeroom.present? || educator.admin?
+
+    educator.save!
     homeroom.update(educator: educator) if homeroom.present?
   end
 

--- a/app/importers/educators_importer.rb
+++ b/app/importers/educators_importer.rb
@@ -13,36 +13,10 @@ class EducatorsImporter
   end
 
   def import_row(row)
-    educator = Educator.where(local_id: row[:local_id]).first_or_create!
-
-    # Set homeroom
-    update_homeroom(educator, row[:homeroom]) if row[:homeroom]
-
-    # Set admin status
-    admin_status = (row[:staff_type].present? && row[:staff_type].downcase == "administrator")
-
-    # Look up school ID
-    school_local_id = row[:school_local_id]
-    school_id = SchoolLocalIdToAppId.instance.ids_dictionary[school_local_id] if school_local_id.present?
-
-    # Set staff_type, name, and IDs
-
-    # There are many ways to set attributes in ActiveRecord.
-    # 'update': saves to db, runs validations, runs callbacks, resets updated_at
-
-    educator.update(
-      state_id: row[:state_id],
-      local_id: row[:local_id],
-      full_name: row[:full_name],
-      staff_type: row[:staff_type],
-      admin: admin_status,
-      school_id: school_id
-    )
-  end
-
-  def update_homeroom(educator, homeroom_name)
-    homeroom = Homeroom.find_by_name!(homeroom_name)
-    homeroom.update(educator: educator) if homeroom
+    educator = EducatorRow.build(row)
+    educator.save!
+    homeroom = Homeroom.find_by_name!(row[:homeroom]) if row[:homeroom].present?
+    homeroom.update(educator: educator) if homeroom.present?
   end
 
 end

--- a/spec/importers/educators_importer_spec.rb
+++ b/spec/importers/educators_importer_spec.rb
@@ -43,6 +43,26 @@ RSpec.describe EducatorsImporter do
                 expect(educator.admin).to eq(false)
                 expect(educator.email).to eq("jyoung@k12.somerville.ma.us")
               end
+
+              context 'multiple educators' do
+                let(:another_homeroom) { FactoryGirl.create(:homeroom) }
+                let(:another_homeroom_name) { another_homeroom.name }
+                let(:another_row) {
+                  {
+                    state_id: "501",
+                    local_id: "201",
+                    full_name: "Gardner, Dylan",
+                    login_name: "dgardner",
+                    homeroom: another_homeroom_name
+                  }
+                }
+                it 'creates multiple educators' do
+                  expect {
+                    described_class.new.import_row(row)
+                    described_class.new.import_row(another_row)
+                  }.to change(Educator, :count).by 2
+                end
+              end
             end
 
             context 'with school local ID' do


### PR DESCRIPTION
## Notes

+ Only import Administrators plus teachers with homerooms for now
+ Data on the remainder of `staff` is ambiguous; see #388 
+ Import the rest and authorize once our understanding of X2 `staff` is clearer 
+ We may decide to use principal admin pages for educator authorization if X2 `staff` data quality stays poor and we can't improve it quickly enough