### PR TITLE
Remove student risk level as a default on student factory

### DIFF
--- a/spec/controllers/schools_controller_spec.rb
+++ b/spec/controllers/schools_controller_spec.rb
@@ -30,7 +30,7 @@ describe SchoolsController, :type => :controller do
   end
 
   describe '#fat_student_hash' do
-    let!(:student) { FactoryGirl.create(:student) }
+    let!(:student) { FactoryGirl.create(:student, :with_risk_level) }
     before { FactoryGirl.create(:student_school_year, student: student) }
     let!(:student_hash) { controller.send(:fat_student_hash, student) }
 

--- a/spec/controllers/students_controller_spec.rb
+++ b/spec/controllers/students_controller_spec.rb
@@ -5,7 +5,7 @@ describe StudentsController, :type => :controller do
   let!(:educator_without_homeroom) { FactoryGirl.create(:educator) }
 
   describe '#show' do
-    let(:student) { FactoryGirl.create(:student) }
+    let(:student) { FactoryGirl.create(:student, :with_risk_level) }
     let!(:student_school_year) { FactoryGirl.create(:student_school_year, student: student) }
 
     def make_request(options = { student_id: nil, format: :html })

--- a/spec/factories/educators.rb
+++ b/spec/factories/educators.rb
@@ -27,13 +27,13 @@ FactoryGirl.define do
     factory :educator_with_homeroom_with_student do
       after(:create) do |educator|
         homeroom = create(:homeroom, educator: educator)
-        create(:student, homeroom: homeroom)
+        create(:student, :with_risk_level, homeroom: homeroom)
       end
     end
     factory :educator_with_homeroom_with_three_students do
       after(:create) do |educator|
         homeroom = create(:homeroom, educator: educator)
-        3.times { create(:student, homeroom: homeroom) }
+        3.times { create(:student, :with_risk_level, homeroom: homeroom) }
       end
     end
     factory :educator_with_homeroom_with_student_with_mcas_math_warning do

--- a/spec/factories/homerooms.rb
+++ b/spec/factories/homerooms.rb
@@ -8,48 +8,58 @@ FactoryGirl.define do
 
   factory :homeroom do
     name { FactoryGirl.generate(:name) }
+
     factory :grade_5_homeroom do
       grade "5"
     end
+
     factory :homeroom_with_student do
       after(:create) do |homeroom|
-        homeroom.students << FactoryGirl.create(:student)
+        homeroom.students << FactoryGirl.create(:student, :with_risk_level)
       end
     end
+
     factory :homeroom_with_second_grader do
       after(:create) do |homeroom|
-        homeroom.students << FactoryGirl.create(:second_grade_student)
+        homeroom.students << FactoryGirl.create(:second_grade_student, :with_risk_level)
       end
     end
+
     factory :homeroom_with_pre_k_student do
       after(:create) do |homeroom|
-        homeroom.students << FactoryGirl.create(:pre_k_student)
+        homeroom.students << FactoryGirl.create(:pre_k_student, :with_risk_level)
       end
     end
+
     factory :homeroom_with_student_with_mcas_math_warning do
       after(:create) do |homeroom|
-        homeroom.students << FactoryGirl.create(:student_with_mcas_math_warning_assessment)
+        homeroom.students << FactoryGirl.create(:student_with_mcas_math_warning_assessment, :with_risk_level)
       end
     end
+
     factory :homeroom_with_student_with_multiple_star_math_student_assessments do
       after(:create) do |homeroom|
-        homeroom.students << FactoryGirl.create(:student_with_star_math_student_assessments_different_days)
+        homeroom.students << FactoryGirl.create(:student_with_star_math_student_assessments_different_days, :with_risk_level)
       end
     end
+
     factory :homeroom_with_one_atp_intervention do
       after(:create) do |homeroom|
-        homeroom.students << FactoryGirl.create(:student_with_one_atp_intervention)
+        homeroom.students << FactoryGirl.create(:student_with_one_atp_intervention, :with_risk_level)
       end
     end
+
     factory :homeroom_with_one_non_atp_intervention do
       after(:create) do |homeroom|
-        homeroom.students << FactoryGirl.create(:student_with_one_non_atp_intervention)
+        homeroom.students << FactoryGirl.create(:student_with_one_non_atp_intervention, :with_risk_level)
       end
     end
+
     factory :homeroom_with_multiple_atp_interventions do
       after(:create) do |homeroom|
-        homeroom.students << FactoryGirl.create(:student_with_multiple_atp_interventions)
+        homeroom.students << FactoryGirl.create(:student_with_multiple_atp_interventions, :with_risk_level)
       end
     end
+
   end
 end

--- a/spec/factories/students.rb
+++ b/spec/factories/students.rb
@@ -7,11 +7,11 @@ FactoryGirl.define do
   factory :student do
     local_id
     association :homeroom
-    after(:create) do |student|
-      # Assume each student has a StudentRiskLevel object created
-      # on initial import (and updated with a daily scheduled job).
-      # If student risk levels are not being created, we want to throw errors.
-      FactoryGirl.create(:student_risk_level, student: student)
+
+    trait :with_risk_level do
+      after(:create) do |student|
+        FactoryGirl.create(:student_risk_level, student: student)
+      end
     end
 
     trait :low_income do

--- a/spec/features/export_profile_feature_spec.rb
+++ b/spec/features/export_profile_feature_spec.rb
@@ -6,7 +6,7 @@ describe 'export profile', :type => :feature do
     let!(:educator) { FactoryGirl.create(:educator_with_homeroom) }
     let!(:student) {
       Timecop.freeze(DateTime.new(2015, 5, 1)) do
-        FactoryGirl.create(:student_who_registered_in_2013_2014)
+        FactoryGirl.create(:student_who_registered_in_2013_2014, :with_risk_level)
       end
     }
 
@@ -32,11 +32,13 @@ describe 'export profile', :type => :feature do
       end
     end
   end
+
   context 'someone without account' do
-    let!(:student) { FactoryGirl.create(:student_who_registered_in_2013_2014) }
+    let!(:student) { FactoryGirl.create(:student_who_registered_in_2013_2014, :with_risk_level) }
     it 'does not work' do
       visit "/students/#{student.id}.csv"
       expect(page).to have_content 'You need to sign in before continuing.'
     end
   end
+
 end

--- a/spec/features/profile_feature_spec.rb
+++ b/spec/features/profile_feature_spec.rb
@@ -14,58 +14,58 @@ describe 'educator views student profile', :type => :feature do
     end
 
     context 'student has no discipline incidents' do
-      let!(:student) { FactoryGirl.create(:student_who_registered_in_2013_2014) }
+      let!(:student) { FactoryGirl.create(:student_who_registered_in_2013_2014, :with_risk_level) }
       it 'shows no discipline incidents' do
         expect(page).to have_content 'No behavior incidents'
       end
     end
     context 'student has discipline incidents' do
-      let!(:student) { FactoryGirl.create(:student_with_discipline_incident) }
+      let!(:student) { FactoryGirl.create(:student_with_discipline_incident, :with_risk_level) }
       it 'shows the discipline incident' do
         expect(page).not_to have_content 'No behavior incidents'
       end
     end
     context 'student has no attendance events' do
-      let!(:student) { FactoryGirl.create(:student_who_registered_in_2013_2014) }
+      let!(:student) { FactoryGirl.create(:student_who_registered_in_2013_2014, :with_risk_level) }
       it 'shows no attendance events' do
         expect(page).to have_content 'No absences or tardies'
       end
     end
     context 'student has absence' do
-      let!(:student) { FactoryGirl.create(:student_with_absence) }
+      let!(:student) { FactoryGirl.create(:student_with_absence, :with_risk_level) }
       it 'shows the absence' do
         expect(page).not_to have_content 'No absences or tardies'
       end
     end
     context 'student has no MCAS results' do
-      let!(:student) { FactoryGirl.create(:student_who_registered_in_2013_2014) }
+      let!(:student) { FactoryGirl.create(:student_who_registered_in_2013_2014, :with_risk_level) }
       it 'shows no MCAS results' do
         expect(page).not_to have_css '.mcas-result-section'
       end
     end
     context 'student has MCAS results' do
       context 'English' do
-        let!(:student) { FactoryGirl.create(:student_with_mcas_ela_assessment) }
+        let!(:student) { FactoryGirl.create(:student_with_mcas_ela_assessment, :with_risk_level) }
         it 'shows MCAS results' do
           expect(page).to have_css '.mcas-ela-values'
         end
       end
       context 'math' do
-        let!(:student) { FactoryGirl.create(:student_with_mcas_math_assessment) }
+        let!(:student) { FactoryGirl.create(:student_with_mcas_math_assessment, :with_risk_level) }
         it 'shows MCAS results' do
           expect(page).to have_css '.mcas-math-values'
         end
       end
     end
     context 'student has no STAR results' do
-      let!(:student) { FactoryGirl.create(:student_who_registered_in_2013_2014) }
+      let!(:student) { FactoryGirl.create(:student_who_registered_in_2013_2014, :with_risk_level) }
       it 'shows no STAR results' do
         expect(page).not_to have_css '.star-result-section'
       end
     end
     context 'student has a STAR result' do
       context 'reading' do
-        let!(:student) { FactoryGirl.create(:student_ahead_in_reading) }
+        let!(:student) { FactoryGirl.create(:student_ahead_in_reading, :with_risk_level) }
         it 'shows STAR result' do
           expect(page).to have_css '.star-reading-values'
         end
@@ -75,32 +75,32 @@ describe 'educator views student profile', :type => :feature do
         end
       end
       context 'math' do
-        let!(:student) { FactoryGirl.create(:student_with_star_math_assessment) }
+        let!(:student) { FactoryGirl.create(:student_with_star_math_assessment, :with_risk_level) }
         it 'shows STAR result' do
           expect(page).to have_css '.star-math-values'
         end
       end
     end
     context 'student has DIBELS' do
-      let!(:student) { FactoryGirl.create(:student_with_dibels) }
+      let!(:student) { FactoryGirl.create(:student_with_dibels, :with_risk_level) }
       it 'shows DIBELS' do
         expect(page).to have_css '.dibels-values'
       end
     end
     context 'student has no DIBELS' do
-      let!(:student) { FactoryGirl.create(:student_who_registered_in_2013_2014) }
+      let!(:student) { FactoryGirl.create(:student_who_registered_in_2013_2014, :with_risk_level) }
       it 'doesn\'t show DIBELS' do
         expect(page).not_to have_css '.dibels-values'
       end
     end
     context 'student has ACCESS' do
-      let!(:student) { FactoryGirl.create(:student_with_access) }
+      let!(:student) { FactoryGirl.create(:student_with_access, :with_risk_level) }
       it 'shows ACCESS' do
         expect(page).to have_css '.access-values'
       end
     end
     context 'student has no ACCESS' do
-      let!(:student) { FactoryGirl.create(:student_who_registered_in_2013_2014) }
+      let!(:student) { FactoryGirl.create(:student_who_registered_in_2013_2014, :with_risk_level) }
       it 'doesn\'t show ACCESS' do
         expect(page).not_to have_css '.access-values'
       end


### PR DESCRIPTION
## Notes

+ There are plenty of methods to test on Student that don't rely on a StudentRiskLevel
+ When StudentRiskLevel is part of the Student factory by default, it makes changing StudentRiskLevel more difficult