### PR TITLE
Make overview page links work in different environments

### DIFF
--- a/app/assets/javascripts/school/helpers/routes.js
+++ b/app/assets/javascripts/school/helpers/routes.js
@@ -1,14 +1,13 @@
 (function() {
   // Routing functions
   window.shared || (window.shared = {});
-  
-  var baseUrl = 'https://somerville-teacher-tool.herokuapp.com'; // for local hacking
+
   window.shared.Routes = {
     student: function(id) {
-      return baseUrl + '/students/' + id;
+      return '/students/' + id;
     },
     homeroom: function(id) {
-      return baseUrl + '/homerooms/' + id;
+      return '/homerooms/' + id;
     }
   };
 })();


### PR DESCRIPTION
## Notes

+ `baseURL` shouldn't be set to production URL; this breaks the app in development and demo environments
+ Plus the URL can change over time
