### PR TITLE
Render whitespace for user-entered text

### DIFF
--- a/app/assets/javascripts/student/interventions_controller_templates.hbs
+++ b/app/assets/javascripts/student/interventions_controller_templates.hbs
@@ -20,7 +20,7 @@
     {{#if renderDeleteButtons}}
       <span class="intervention-delete-button">x</span>
     {{/if}}
-    <p>{{comment}}</p>
+    <p class="intervention-comment">{{comment}}</p>
     <p class="intervention-date">
       {{start_date}} - {{end_date}}
     </p>
@@ -34,9 +34,9 @@
   <div class="intervention-detail" data-id="{{id}}">
     <h2>{{name}}</h2>
     <strong>Description</strong>
-    <p>{{comment}}</p>
+    <p class="intervention-usertext">{{comment}}</p>
     <strong>Goal</strong>
-    <p>{{goal}}</p>
+    <p class="intervention-usertext">{{goal}}</p>
     <strong>Start Date</strong>
     <p>{{start_date}}</p>
     <strong>End Date</strong>
@@ -110,12 +110,10 @@
     <strong>
       {{educator_email}}
     </strong>
-    <p>
-      {{content}}
-      <br/>
-      <span class="smalltype">
-        {{created_date}}
-      </span>
+    <p class="progress-note-comment">{{content}}</p>
+    <div class="smalltype">
+      {{created_date}}
+    </div>
     </p>
   </div>
 {{/progressNote}}

--- a/app/assets/javascripts/student/student_notes_controller_templates.hbs
+++ b/app/assets/javascripts/student/student_notes_controller_templates.hbs
@@ -20,8 +20,6 @@
     <div class="student-note-date">
       {{created_at}}
     </div>
-    <div class="student-note-content">
-      {{content}}
-    </div>
+    <div class="student-note-content">{{content}}</div>
   </div>
 {{/studentNote}}

--- a/app/assets/stylesheets/student.scss
+++ b/app/assets/stylesheets/student.scss
@@ -82,9 +82,20 @@
       border-bottom: 1px solid $light-line;
       margin-bottom: 20px;
     }
+
     p {
       margin-bottom: 20px;
     }
+
+    .intervention-usertext {
+      white-space: pre-wrap;
+    }
+
+    .progress-note-comment {
+      white-space: pre-wrap;
+      margin-bottom: 5px;
+    }
+
     .add-progress-note-area {
       .btn {
         float: left;
@@ -352,4 +363,8 @@
   float: right;
   font-weight: bold;
   color: $gray;
+}
+
+.intervention-comment {
+  white-space: pre-wrap;
 }

--- a/app/assets/stylesheets/student_note.scss
+++ b/app/assets/stylesheets/student_note.scss
@@ -41,6 +41,10 @@
     }
   }
 
+  .student-note-content {
+    white-space: pre-wrap;
+  }
+
   .btn {
     float: left;
     margin: 20px 10px 20px 0;


### PR DESCRIPTION
Previously, if users were using whitespace in text fields (eg., line breaks, spaces), they wouldn't be rendered back to them.

Notes page, before:
<img width="436" alt="screen shot 2016-02-01 at 3 40 38 pm" src="https://cloud.githubusercontent.com/assets/1056957/12730779/8503b1c4-c8fb-11e5-9335-490b69e8bd6b.png">

Notes page, after:
<img width="256" alt="screen shot 2016-02-01 at 3 48 46 pm" src="https://cloud.githubusercontent.com/assets/1056957/12730777/8114d44e-c8fb-11e5-9d9d-e6595fd9c848.png">

Intervention text, before:
<img width="441" alt="screen shot 2016-02-01 at 3 41 25 pm" src="https://cloud.githubusercontent.com/assets/1056957/12730799/9edcffe2-c8fb-11e5-80b3-4bbd2ee12258.png">

Intervention text, after:
<img width="425" alt="screen shot 2016-02-01 at 3 43 34 pm" src="https://cloud.githubusercontent.com/assets/1056957/12730808/a805ab64-c8fb-11e5-9143-efce277d29f8.png">
<img width="564" alt="screen shot 2016-02-01 at 3 53 00 pm" src="https://cloud.githubusercontent.com/assets/1056957/12730858/e87b2958-c8fb-11e5-893e-6a3b1ba2220f.png">


Progress note, before:
<img width="361" alt="screen shot 2016-02-01 at 3 43 52 pm" src="https://cloud.githubusercontent.com/assets/1056957/12730811/add045b8-c8fb-11e5-827a-131596220539.png">

Progress note, after:
<img width="351" alt="screen shot 2016-02-01 at 3 49 47 pm" src="https://cloud.githubusercontent.com/assets/1056957/12730820/b5625654-c8fb-11e5-9b43-7f7951cc4c3b.png">
