### PR TITLE
Make download as CSV filename more explicit on dashboard page

### DIFF
--- a/app/assets/javascripts/school_overview/school_overview_page.js
+++ b/app/assets/javascripts/school_overview/school_overview_page.js
@@ -278,11 +278,14 @@
         ].join(',');
       });
       var csvText = [header].concat(rows).join('\n');
+      var dateText = moment().format('YYYY-MM-DD');
+      var filtersText = (this.activeFiltersIdentifier().length === 0) ? '' : ' (' + this.activeFiltersIdentifier() + ')';
+      var filename = 'Students on ' + dateText + filtersText + '.csv';
 
       return dom.a({
         href: 'data:attachment/csv,' + encodeURIComponent(csvText),
         target: '_blank',
-        download: 'student.csv',
+        download: filename,
         style: {
           paddingLeft: 20,
           fontSize: styles.fontSize


### PR DESCRIPTION
This was just `student.csv` in the initial version, update it to have the date and data about filters applied as well.

<img width="583" alt="screen shot 2016-02-02 at 9 42 25 am" src="https://cloud.githubusercontent.com/assets/1056957/12752634/7a9dd818-c991-11e5-912a-2f5960463ecf.png">
