### PR TITLE
Remove unused export button from Roster page, remove arrow from stude…

### DIFF
--- a/app/views/homerooms/show.html.erb
+++ b/app/views/homerooms/show.html.erb
@@ -11,9 +11,6 @@
     </div>
     <div id="student-searchbar-wrapper" class="dropdown">
     </div>
-    <div id="export">
-      <%= link_to "Export &#9662;".html_safe, @csv_url, method: "get", id: 'export-button' %>
-    </div>
   </div>
   <div class="info-area">
 

--- a/app/views/students/show.html.erb
+++ b/app/views/students/show.html.erb
@@ -3,7 +3,7 @@
       <%= link_to "< Back to roster for #{@student.homeroom.name}", @roster_url %>
     </div>
     <div id="export">
-      <%= link_to "Export &#9662;".html_safe, @csv_url, method: "get", id: 'export-button' %>
+      <%= link_to 'Export', @csv_url, method: "get", id: 'export-button' %>
     </div>
   </div>
 


### PR DESCRIPTION
…nt profile export.  Also remove down arrow styling on student profile page export button, since functionally it's just a plain button.  This closes https://github.com/codeforamerica/somerville-teacher-tool/issues/75.

Before:
<img width="1040" alt="screen shot 2016-02-02 at 10 17 30 am" src="https://cloud.githubusercontent.com/assets/1056957/12753769/67873fd0-c996-11e5-8c68-3bcb9b51dd9c.png">
<img width="1055" alt="screen shot 2016-02-02 at 10 18 34 am" src="https://cloud.githubusercontent.com/assets/1056957/12753789/80f168ce-c996-11e5-9f35-d9243f1292ca.png">


After:
<img width="1027" alt="screen shot 2016-02-02 at 10 19 34 am" src="https://cloud.githubusercontent.com/assets/1056957/12753782/798b0bd0-c996-11e5-8a6f-e645f366d462.png">
<img width="1051" alt="screen shot 2016-02-02 at 10 18 05 am" src="https://cloud.githubusercontent.com/assets/1056957/12753792/845adc3e-c996-11e5-84ce-90f851d8901a.png">