### PR TITLE
Change redirect from invalid homeroom_id to respect user role

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -19,13 +19,20 @@ class ApplicationController < ActionController::Base
     redirect_to(new_educator_session_path) unless current_educator.admin?
   end
 
-  private
+  # Return the homepage path, depending on the educator's role
+  def homepage_path_for_role(educator)
+    if educator.admin?
+      school_url(educator.default_school_for_admin)
+    else
+      default_homeroom_path(educator)
+    end
+  end
 
-  def redirect_to_default_homeroom
-    redirect_to homeroom_path(current_educator.default_homeroom)
+  def default_homeroom_path(educator)
+    homeroom_path(educator.default_homeroom)
   rescue Exceptions::NoAssignedHomeroom   # Thrown by educator without default homeroom
-    redirect_to no_homeroom_path
+    no_homeroom_path
   rescue Exceptions::NoHomerooms
-    redirect_to no_homerooms_path
+    no_homerooms_path
   end
 end

--- a/app/controllers/educators_controller.rb
+++ b/app/controllers/educators_controller.rb
@@ -3,11 +3,7 @@ class EducatorsController < ApplicationController
   # Authentication by default inherited from ApplicationController.
 
   def homepage
-    if current_educator.admin?
-      redirect_to school_url(current_educator.default_school_for_admin)
-    else
-      redirect_to_default_homeroom
-    end
+    redirect_to homepage_path_for_role(current_educator)
   end
 
   def reset_session_clock

--- a/app/controllers/homerooms_controller.rb
+++ b/app/controllers/homerooms_controller.rb
@@ -71,10 +71,9 @@ class HomeroomsController < ApplicationController
     if current_educator.allowed_homerooms.include? @requested_homeroom
       @homeroom = @requested_homeroom
     else
-      redirect_to_default_homeroom
+      redirect_to homepage_path_for_role(current_educator)
     end
   rescue ActiveRecord::RecordNotFound     # Params don't match an actual homeroom
-    redirect_to_default_homeroom
+    redirect_to homepage_path_for_role(current_educator)
   end
-
 end

--- a/spec/controllers/homerooms_controller_spec.rb
+++ b/spec/controllers/homerooms_controller_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 describe HomeroomsController, :type => :controller do
-
+  let!(:school) { FactoryGirl.create(:school) }
   let!(:educator) { FactoryGirl.create(:educator_with_grade_5_homeroom) }
   let!(:educator_without_homeroom) { FactoryGirl.create(:educator) }
   let!(:admin_educator) { FactoryGirl.create(:educator, :admin) }
@@ -111,9 +111,9 @@ describe HomeroomsController, :type => :controller do
         end
 
         context 'garbage homeroom params' do
-          it 'redirects to first homeroom' do
+          it 'redirects to overview page' do
             make_request('garbage homeroom ids rule')
-            expect(response).to redirect_to(no_homeroom_url)
+            expect(response).to redirect_to(school_url(school))
           end
         end
 


### PR DESCRIPTION
I encountered a redirect to the "Looks like there's no homeroom assigned to you." page earlier on the demo site, and @marimuraki reported the same thing too.

This happens because the educator account doesn't have a `default_homeroom` set.  This is valid for administrators though (which is what the `demo@` account is supposed to show).  This updates code in `homerooms_controller` that redirects to the user's default homeroom in some failure scenarios (like if the user doesn't have a homeroom set, or the homeroom id is invalid).

This change pushes the branching for the homepage URL based on role down to a `homepage_path_for_role` method in `application_controller`, and uses that instead.

You can reproduce visiting `/homerooms/foo` as an admin user, which perhaps was coming up on the demo site from a stale redirect URL.