### PR TITLE
Expose Rails env and DEMO_SITE flag to JS UI, include it in usage metrics

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -32,6 +32,7 @@
 //= require react
 
 // shared across application:
+//= require env
 //= require datepicker_config
 //= require session_timeout_warning
 //= require student_searchbar

--- a/app/assets/javascripts/env.js.erb
+++ b/app/assets/javascripts/env.js.erb
@@ -1,0 +1,9 @@
+(function() {
+  window.shared || (window.shared = {});
+
+  // Describe server-side environment and configuration to the JS UI code.
+  window.shared.Env = {
+    railsEnvironment: '<%= Rails.env %>',
+    isDemoSite: <%= if ENV['DEMO_SITE'] then 'true' else 'false' end %>
+  };
+})();

--- a/app/assets/javascripts/helpers/mixpanel_utils.js
+++ b/app/assets/javascripts/helpers/mixpanel_utils.js
@@ -1,10 +1,14 @@
 (function() {
   // Define filter operations
   window.shared || (window.shared = {});
+  var Env = window.shared.Env;
+
   window.shared.MixpanelUtils = {
     registerUser: function(currentEducator) {
       if (!window.mixpanel) return;
+      if (Env.railsEnvironment !== 'production') return;
       window.mixpanel.register({
+        'isDemoSite': Env.isDemoSite,
         'educator_id': currentEducator.id,
         'educator_is_admin': currentEducator.admin,
         'educator_school_id': currentEducator.school_id


### PR DESCRIPTION
Track whether user sessions are happening on production site or demo site (both useful in different ways).