### PR TITLE
Restore email uniqueness validation

### DIFF
--- a/app/models/educator.rb
+++ b/app/models/educator.rb
@@ -12,7 +12,7 @@ class Educator < ActiveRecord::Base
   has_many    :progress_notes, through: :interventions
   has_many    :student_notes
 
-  validates_uniqueness_of :email
+  validates :email, presence: true, uniqueness: true
 
   def default_homeroom
     raise Exceptions::NoHomerooms if Homeroom.count == 0    # <= We can't show any homerooms if there are none

--- a/app/models/educator.rb
+++ b/app/models/educator.rb
@@ -12,6 +12,8 @@ class Educator < ActiveRecord::Base
   has_many    :progress_notes, through: :interventions
   has_many    :student_notes
 
+  validates_uniqueness_of :email
+
   def default_homeroom
     raise Exceptions::NoHomerooms if Homeroom.count == 0    # <= We can't show any homerooms if there are none
     return homeroom if homeroom.present?                    # <= Logged-in educator has an assigned homeroom


### PR DESCRIPTION
## Notes

+ I removed Devise `:validatable` because we no longer store user passwords because LDAP
+ But that removed email uniqueness validation too!
+ We don't want multiple Educator records with the same email address