### PR TITLE
More granular permissions for educators

### DIFF
--- a/app/controllers/students_controller.rb
+++ b/app/controllers/students_controller.rb
@@ -7,11 +7,17 @@ class StudentsController < ApplicationController
 
   def authorize!
     student = Student.find(params[:id])
+    educator = current_educator
 
+    raise Exceptions::EducatorNotAuthorized if educator.restricted_to_sped_students &&
+                                               !(student.program_assigned.in? ['Sp Ed', 'SEIP'])
+
+    raise Exceptions::EducatorNotAuthorized if educator.restricted_to_english_language_learners &&
+                                               student.limited_english_proficiency == 'Fluent'
     allowed_conditions = [
-      current_educator.schoolwide_access,                       # <= Schoolwide admin
-      student.grade.in?(current_educator.grade_level_access),   # <= Grade level access
-      student.in?(current_educator.students)                    # <= Homeroom level access
+      educator.schoolwide_access,                       # <= Schoolwide admin
+      student.grade.in?(educator.grade_level_access),   # <= Grade level access
+      student.in?(educator.students)                    # <= Homeroom level access
     ]
 
     raise Exceptions::EducatorNotAuthorized unless allowed_conditions.any?

--- a/app/importers/educator_row.rb
+++ b/app/importers/educator_row.rb
@@ -12,6 +12,7 @@ class EducatorRow < Struct.new(:row, :school_ids_dictionary)
       full_name: row[:full_name],
       staff_type: row[:staff_type],
       admin: is_admin?,
+      schoolwide_access: is_admin?,
       email: row[:login_name] + '@k12.somerville.ma.us',
       school_id: school_rails_id
     )

--- a/app/importers/educators_importer.rb
+++ b/app/importers/educators_importer.rb
@@ -17,12 +17,10 @@ class EducatorsImporter
   end
 
   def import_row(row)
-    homeroom = Homeroom.find_by_name!(row[:homeroom]) if row[:homeroom].present?
     educator = EducatorRow.new(row, @school_ids_dictionary).build
-
-    return unless homeroom.present? || educator.admin?
-
     educator.save!
+
+    homeroom = Homeroom.find_by_name!(row[:homeroom]) if row[:homeroom].present?
     homeroom.update(educator: educator) if homeroom.present?
   end
 

--- a/app/models/educator.rb
+++ b/app/models/educator.rb
@@ -65,6 +65,12 @@ class Educator < ActiveRecord::Base
       puts "#{educator.full_name} -- #{educator.grade_level_access}"
     end
 
+    puts; puts "=== Staff members limited to student profiles of ELLs:"
+    puts Educator.where(restricted_to_english_language_learners: true).pluck(:full_name)
+
+    puts; puts "=== Staff members limited to student profiles of SPED students:"
+    puts Educator.where(restricted_to_sped_students: true).pluck(:full_name)
+
     puts; puts "=== Homeroom teachers:"
     Educator.all.select { |e| e.homeroom.present? }.each do |educator|
       puts "#{educator.full_name} -- #{educator.homeroom.name} -- Grade #{educator.homeroom.grade}"

--- a/app/models/educator.rb
+++ b/app/models/educator.rb
@@ -49,10 +49,37 @@ class Educator < ActiveRecord::Base
 
   def self.summary
     puts; puts "=== EDUCATOR REPORT ==="
-    puts; puts "=== ADMINS ==="
+
+    puts; puts "=== Admins:"
     puts Educator.where(admin: true).pluck(:full_name)
-    puts; puts "=== HOMEROOM TEACHERS ==="
-    puts Educator.all.select { |e| e.homeroom.present? }.map { |e| e.full_name }
+
+    puts; puts "=== Non-admins with school-wide access:"
+    puts Educator.where(admin: false, schoolwide_access: true).pluck(:full_name)
+
+    puts; puts "=== Staff members with grade level-based access:"
+    Educator.where(admin: false)
+            .where(schoolwide_access: false)
+            .select { |e| e.homeroom.blank? }
+            .select { |e| e.grade_level_access.size > 0 }
+            .each do |educator|
+      puts "#{educator.full_name} -- #{educator.grade_level_access}"
+    end
+
+    puts; puts "=== Homeroom teachers:"
+    Educator.all.select { |e| e.homeroom.present? }.each do |educator|
+      puts "#{educator.full_name} -- #{educator.homeroom.name} -- Grade #{educator.homeroom.grade}"
+    end
+
+    puts; puts "=== Without any authorizations:"
+    Educator.where(admin: false)
+            .where(schoolwide_access: false)
+            .select { |e| e.grade_level_access.empty? }
+            .select { |e| e.homeroom.blank? }
+            .each do |educator|
+      puts educator.full_name
+    end
+
+    return
   end
 
 end

--- a/app/models/educator.rb
+++ b/app/models/educator.rb
@@ -36,6 +36,8 @@ class Educator < ActiveRecord::Base
       # Once the app includes data for multiple schools, will
       # need to scope by school as well as by grade level
       Homeroom.where(grade: homeroom.grade)
+    elsif grade_level_access.present?
+      Homeroom.where(grade: grade_level_access)
     else
       []
     end

--- a/app/models/educator.rb
+++ b/app/models/educator.rb
@@ -30,7 +30,7 @@ class Educator < ActiveRecord::Base
     # Educator can visit roster view for these homerooms
     # For non-admins, all homerooms at their homeroom's grade level
 
-    if admin?
+    if schoolwide_access?
       Homeroom.all
     elsif homeroom
       # Once the app includes data for multiple schools, will

--- a/app/models/educator.rb
+++ b/app/models/educator.rb
@@ -47,45 +47,4 @@ class Educator < ActiveRecord::Base
     allowed_homerooms.order(:name)
   end
 
-  def self.summary
-    puts; puts "=== EDUCATOR REPORT ==="
-
-    puts; puts "=== Admins:"
-    puts Educator.where(admin: true).pluck(:full_name)
-
-    puts; puts "=== Non-admins with school-wide access:"
-    puts Educator.where(admin: false, schoolwide_access: true).pluck(:full_name)
-
-    puts; puts "=== Staff members with grade level-based access:"
-    Educator.where(admin: false)
-            .where(schoolwide_access: false)
-            .select { |e| e.homeroom.blank? }
-            .select { |e| e.grade_level_access.size > 0 }
-            .each do |educator|
-      puts "#{educator.full_name} -- #{educator.grade_level_access}"
-    end
-
-    puts; puts "=== Staff members limited to student profiles of ELLs:"
-    puts Educator.where(restricted_to_english_language_learners: true).pluck(:full_name)
-
-    puts; puts "=== Staff members limited to student profiles of SPED students:"
-    puts Educator.where(restricted_to_sped_students: true).pluck(:full_name)
-
-    puts; puts "=== Homeroom teachers:"
-    Educator.all.select { |e| e.homeroom.present? }.each do |educator|
-      puts "#{educator.full_name} -- #{educator.homeroom.name} -- Grade #{educator.homeroom.grade}"
-    end
-
-    puts; puts "=== Without any authorizations:"
-    Educator.where(admin: false)
-            .where(schoolwide_access: false)
-            .select { |e| e.grade_level_access.empty? }
-            .select { |e| e.homeroom.blank? }
-            .each do |educator|
-      puts educator.full_name
-    end
-
-    return
-  end
-
 end

--- a/app/models/educator_summary.rb
+++ b/app/models/educator_summary.rb
@@ -1,0 +1,44 @@
+class EducatorSummary
+
+  def report
+    puts; puts "=== EDUCATOR REPORT ==="
+
+    puts; puts "=== Admins:"
+    puts Educator.where(admin: true).pluck(:full_name)
+
+    puts; puts "=== Non-admins with school-wide access:"
+    puts Educator.where(admin: false, schoolwide_access: true).pluck(:full_name)
+
+    puts; puts "=== Staff members with grade level-based access:"
+    Educator.where(admin: false)
+            .where(schoolwide_access: false)
+            .select { |e| e.homeroom.blank? }
+            .select { |e| e.grade_level_access.size > 0 }
+            .each do |educator|
+      puts "#{educator.full_name} -- #{educator.grade_level_access}"
+    end
+
+    puts; puts "=== Staff members limited to student profiles of ELLs:"
+    puts Educator.where(restricted_to_english_language_learners: true).pluck(:full_name)
+
+    puts; puts "=== Staff members limited to student profiles of SPED students:"
+    puts Educator.where(restricted_to_sped_students: true).pluck(:full_name)
+
+    puts; puts "=== Homeroom teachers:"
+    Educator.all.select { |e| e.homeroom.present? }.each do |educator|
+      puts "#{educator.full_name} -- #{educator.homeroom.name} -- Grade #{educator.homeroom.grade}"
+    end
+
+    puts; puts "=== Without any authorizations:"
+    Educator.where(admin: false)
+            .where(schoolwide_access: false)
+            .select { |e| e.grade_level_access.empty? }
+            .select { |e| e.homeroom.blank? }
+            .each do |educator|
+      puts educator.full_name
+    end
+
+    return
+  end
+
+end

--- a/app/models/educator_summary.rb
+++ b/app/models/educator_summary.rb
@@ -25,7 +25,9 @@ class EducatorSummary
     puts Educator.where(restricted_to_sped_students: true).pluck(:full_name)
 
     puts; puts "=== Homeroom teachers:"
-    Educator.all.select { |e| e.homeroom.present? }.each do |educator|
+    Educator.all.select { |e| e.homeroom.present? }
+                .sort_by { |e| e.homeroom.grade }
+                .each do |educator|
       puts "#{educator.full_name} -- #{educator.homeroom.name} -- Grade #{educator.homeroom.grade}"
     end
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -24,8 +24,7 @@
               <input id="student-searchbar" />
               <% if current_educator.admin? %>
                 <% unless controller_name == 'schools' && action_name == 'show' %>
-                  <% current_school = current_educator.try(:allowed_homerooms).try(:first).try(:students).try(:first).try(:school) %>
-                  <%= link_to 'School Overview Dashboard', school_path(current_school.id) %>
+                  <%= link_to 'School Overview Dashboard', school_path(School.first) %>
                 <% end %>
               <% end %>
             </div>

--- a/app/views/pages/not_authorized.html.erb
+++ b/app/views/pages/not_authorized.html.erb
@@ -1,0 +1,7 @@
+<div class="info-area">
+  You don't have the correct authorization for this page.
+  <br/>
+  Please check with the principal or school secretary if you feel this is incorrect.
+  <br/>
+  You can also get in touch with the project developers by <a href="https://github.com/codeforamerica/somerville-teacher-tool/issues/new">opening a GitHub issue</a>.
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,6 +10,7 @@ Rails.application.routes.draw do
   get 'about' => 'pages#about'
   get 'no_homeroom' => 'pages#no_homeroom'
   get 'no_homerooms' => 'pages#no_homerooms'
+  get 'not_authorized' => 'pages#not_authorized'
 
   get '/students/names' => 'students#names'
   get '/educators/reset'=> 'educators#reset_session_clock'

--- a/db/migrate/20160204001545_add_permissions_fields_for_educators.rb
+++ b/db/migrate/20160204001545_add_permissions_fields_for_educators.rb
@@ -1,0 +1,7 @@
+class AddPermissionsFieldsForEducators < ActiveRecord::Migration
+  def change
+    add_column :educators, :schoolwide_access, :boolean, default: false
+    add_column :educators, :grade_level_access, :string, array: true
+    add_index  :educators, :grade_level_access, using: 'gin'
+  end
+end

--- a/db/migrate/20160204003848_add_default_value_to_educator_grade_level_access.rb
+++ b/db/migrate/20160204003848_add_default_value_to_educator_grade_level_access.rb
@@ -1,0 +1,5 @@
+class AddDefaultValueToEducatorGradeLevelAccess < ActiveRecord::Migration
+  def change
+    change_column :educators, :grade_level_access, :string, array: true, default: []
+  end
+end

--- a/db/migrate/20160204033744_add_restricted_access_fields_to_educators.rb
+++ b/db/migrate/20160204033744_add_restricted_access_fields_to_educators.rb
@@ -1,0 +1,6 @@
+class AddRestrictedAccessFieldsToEducators < ActiveRecord::Migration
+  def change
+    add_column :educators, :restricted_to_sped_students, :boolean, default: false
+    add_column :educators, :restricted_to_english_language_learners, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160130143407) do
+ActiveRecord::Schema.define(version: 20160204001545) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -78,8 +78,11 @@ ActiveRecord::Schema.define(version: 20160130143407) do
     t.string   "local_id"
     t.string   "staff_type"
     t.integer  "school_id"
+    t.boolean  "schoolwide_access",      default: false
+    t.string   "grade_level_access",                                  array: true
   end
 
+  add_index "educators", ["grade_level_access"], name: "index_educators_on_grade_level_access", using: :gin
   add_index "educators", ["reset_password_token"], name: "index_educators_on_reset_password_token", unique: true, using: :btree
 
   create_table "friendly_id_slugs", force: true do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160204001545) do
+ActiveRecord::Schema.define(version: 20160204003848) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -79,7 +79,7 @@ ActiveRecord::Schema.define(version: 20160204001545) do
     t.string   "staff_type"
     t.integer  "school_id"
     t.boolean  "schoolwide_access",      default: false
-    t.string   "grade_level_access",                                  array: true
+    t.string   "grade_level_access",     default: [],                 array: true
   end
 
   add_index "educators", ["grade_level_access"], name: "index_educators_on_grade_level_access", using: :gin

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160204003848) do
+ActiveRecord::Schema.define(version: 20160204033744) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -59,27 +59,29 @@ ActiveRecord::Schema.define(version: 20160204003848) do
   add_index "discipline_incidents", ["student_school_year_id"], name: "index_discipline_incidents_on_student_school_year_id", using: :btree
 
   create_table "educators", force: true do |t|
-    t.string   "email",                  default: "",    null: false
-    t.string   "encrypted_password",     default: "",    null: false
+    t.string   "email",                                   default: "",    null: false
+    t.string   "encrypted_password",                      default: "",    null: false
     t.string   "reset_password_token"
     t.datetime "reset_password_sent_at"
     t.datetime "remember_created_at"
-    t.integer  "sign_in_count",          default: 0,     null: false
+    t.integer  "sign_in_count",                           default: 0,     null: false
     t.datetime "current_sign_in_at"
     t.datetime "last_sign_in_at"
     t.inet     "current_sign_in_ip"
     t.inet     "last_sign_in_ip"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.boolean  "admin",                  default: false
+    t.boolean  "admin",                                   default: false
     t.string   "phone"
     t.string   "full_name"
     t.string   "state_id"
     t.string   "local_id"
     t.string   "staff_type"
     t.integer  "school_id"
-    t.boolean  "schoolwide_access",      default: false
-    t.string   "grade_level_access",     default: [],                 array: true
+    t.boolean  "schoolwide_access",                       default: false
+    t.string   "grade_level_access",                      default: [],                 array: true
+    t.boolean  "restricted_to_sped_students",             default: false
+    t.boolean  "restricted_to_english_language_learners", default: false
   end
 
   add_index "educators", ["grade_level_access"], name: "index_educators_on_grade_level_access", using: :gin

--- a/lib/exceptions.rb
+++ b/lib/exceptions.rb
@@ -1,4 +1,5 @@
 module Exceptions
   class NoAssignedHomeroom < StandardError; end
   class NoHomerooms < StandardError; end
+  class EducatorNotAuthorized < StandardError; end
 end

--- a/spec/controllers/homerooms_controller_spec.rb
+++ b/spec/controllers/homerooms_controller_spec.rb
@@ -96,6 +96,7 @@ describe HomeroomsController, :type => :controller do
         end
 
         context 'homeroom does not belong to educator' do
+
           context 'homeroom is grade level as educator\'s' do
             let(:homeroom) { FactoryGirl.create(:grade_5_homeroom) }
             it 'is successful' do
@@ -103,6 +104,7 @@ describe HomeroomsController, :type => :controller do
               expect(response).to be_success
             end
           end
+
           context 'homeroom is different grade level from educator\'s' do
             let(:homeroom) { FactoryGirl.create(:homeroom) }
             it 'redirects to educator\'s homeroom' do
@@ -110,6 +112,27 @@ describe HomeroomsController, :type => :controller do
               expect(response).to redirect_to(homeroom_path(educator.homeroom))
             end
           end
+
+          context 'educator has appropriate grade level access' do
+            let(:educator) { FactoryGirl.create(:educator, grade_level_access: ['5'] )}
+            let(:homeroom) { FactoryGirl.create(:grade_5_homeroom) }
+
+            it 'is successful' do
+              make_request(homeroom.slug)
+              expect(response).to be_success
+            end
+          end
+
+          context 'educator does not have appropriate grade level access' do
+            let(:educator) { FactoryGirl.create(:educator, grade_level_access: ['3'] )}
+            let(:homeroom) { FactoryGirl.create(:grade_5_homeroom) }
+
+            it 'redirects' do
+              make_request(homeroom.slug)
+              expect(response).to redirect_to(no_homeroom_url)
+            end
+          end
+
         end
 
       end

--- a/spec/factories/educators.rb
+++ b/spec/factories/educators.rb
@@ -8,6 +8,7 @@ FactoryGirl.define do
 
     trait :admin do
       admin true
+      schoolwide_access true
     end
 
     trait :local_id_200 do

--- a/spec/features/export_profile_feature_spec.rb
+++ b/spec/features/export_profile_feature_spec.rb
@@ -3,7 +3,9 @@ require 'capybara/rspec'
 
 describe 'export profile', :type => :feature do
   context 'educator with account' do
-    let!(:educator) { FactoryGirl.create(:educator_with_homeroom) }
+    let!(:school) { FactoryGirl.create(:school) }
+    let!(:educator) { FactoryGirl.create(:educator, :admin) }
+
     let!(:student) {
       Timecop.freeze(DateTime.new(2015, 5, 1)) do
         FactoryGirl.create(:student_who_registered_in_2013_2014, :with_risk_level)

--- a/spec/features/profile_feature_spec.rb
+++ b/spec/features/profile_feature_spec.rb
@@ -3,7 +3,8 @@ require 'capybara/rspec'
 
 describe 'educator views student profile', :type => :feature do
   context 'educator with account views student profile' do
-    let!(:educator) { FactoryGirl.create(:educator_with_homeroom) }
+    let!(:school) { FactoryGirl.create(:school) }
+    let!(:educator) { FactoryGirl.create(:educator, :admin) }
 
     before(:each) do
       Timecop.freeze(DateTime.new(2015, 5, 1)) do

--- a/spec/importers/educators_importer_spec.rb
+++ b/spec/importers/educators_importer_spec.rb
@@ -12,8 +12,19 @@ RSpec.describe EducatorsImporter do
             let(:row) {
               { state_id: "500", local_id: "200", full_name: "Young, Jenny", login_name: "jyoung" }
             }
-            it 'does not create an educator' do
-              expect { described_class.new.import_row(row) }.to change(Educator, :count).by 0
+
+            before do
+              described_class.new.import_row(row)
+            end
+
+            it 'creates an educator' do
+              expect(Educator.count).to eq(1)
+            end
+            it 'does not give educator school wide access' do
+              expect(Educator.first.schoolwide_access).to eq false
+            end
+            it 'does not give educator a homeroom' do
+              expect(Educator.first.homeroom).to eq nil
             end
           end
 

--- a/spec/importers/educators_importer_spec.rb
+++ b/spec/importers/educators_importer_spec.rb
@@ -41,6 +41,7 @@ RSpec.describe EducatorsImporter do
                 expect(educator.state_id).to eq("500")
                 expect(educator.local_id).to eq("200")
                 expect(educator.admin).to eq(false)
+                expect(educator.schoolwide_access).to eq(false)
                 expect(educator.email).to eq("jyoung@k12.somerville.ma.us")
               end
 
@@ -121,6 +122,7 @@ RSpec.describe EducatorsImporter do
             described_class.new.import_row(row)
             educator = Educator.last
             expect(educator.admin).to eq(true)
+            expect(educator.schoolwide_access).to eq(true)
           end
         end
 

--- a/spec/models/educator_spec.rb
+++ b/spec/models/educator_spec.rb
@@ -1,13 +1,85 @@
 require 'rails_helper'
 
 RSpec.describe Educator do
-  describe '#create' do
-    let(:attributes) { FactoryGirl.attributes_for(:educator) }
 
-    it 'makes a new educator in the database' do
-      expect {
-        Educator.create!(attributes)
-      }.to change(Educator, :count).by(1)
+  describe '#default_homeroom' do
+
+    context 'no homerooms' do
+      let(:educator) { FactoryGirl.create(:educator) }
+
+      it 'raises an error' do
+        expect { educator.default_homeroom }.to raise_error Exceptions::NoHomerooms
+      end
+    end
+
+    context 'educator assigned a homeroom' do
+      let(:educator) { FactoryGirl.create(:educator) }
+      let!(:homeroom) { FactoryGirl.create(:homeroom, educator: educator) }
+
+      it 'raises an error' do
+        expect(educator.default_homeroom).to eq homeroom
+      end
+    end
+
+    context 'educator not assigned a homeroom' do
+      let!(:homeroom) { FactoryGirl.create(:homeroom) }
+      let(:educator) { FactoryGirl.create(:educator) }
+
+      it 'raises an error' do
+        expect { educator.default_homeroom }.to raise_error Exceptions::NoAssignedHomeroom
+      end
+    end
+
+  end
+
+  describe '#allowed_homerooms' do
+
+    context 'admin' do
+      let(:educator) { FactoryGirl.create(:educator, schoolwide_access: true) }
+      let!(:homeroom_101) { FactoryGirl.create(:homeroom) }
+      let!(:homeroom_102) { FactoryGirl.create(:homeroom) }
+      let!(:homeroom_103) { FactoryGirl.create(:homeroom, grade: '2') }
+
+      it 'returns all homerooms' do
+        expect(educator.allowed_homerooms).to eq [homeroom_101, homeroom_102, homeroom_103]
+      end
+    end
+
+    context 'homeroom teacher' do
+      let(:educator) { FactoryGirl.create(:educator) }
+      let!(:homeroom_101) { FactoryGirl.create(:homeroom, grade: 'K', educator: educator) }
+      let!(:homeroom_102) { FactoryGirl.create(:homeroom, grade: 'K') }
+      let!(:homeroom_103) { FactoryGirl.create(:homeroom, grade: '2') }
+
+      it 'returns the teacher\'s homeroom and other homerooms with the same grade level' do
+        expect(educator.allowed_homerooms).to eq [homeroom_101, homeroom_102]
+      end
+    end
+
+    context 'teacher with grade level access' do
+      let(:educator) { FactoryGirl.create(:educator, grade_level_access: ['2']) }
+      let!(:homeroom_101) { FactoryGirl.create(:homeroom, grade: 'K') }
+      let!(:homeroom_102) { FactoryGirl.create(:homeroom, grade: 'K') }
+      let!(:homeroom_103) { FactoryGirl.create(:homeroom, grade: '2') }
+
+      it 'returns all homerooms that match the grade level access' do
+        expect(educator.allowed_homerooms).to eq [homeroom_103]
+      end
+    end
+
+  end
+
+  describe '#allowed_homerooms_by_name' do
+    context 'admin' do
+      let(:educator) { FactoryGirl.create(:educator, schoolwide_access: true) }
+      let!(:homeroom_101) { FactoryGirl.create(:homeroom, name: 'Muskrats') }
+      let!(:homeroom_102) { FactoryGirl.create(:homeroom, name: 'Hawks') }
+      let!(:homeroom_103) { FactoryGirl.create(:homeroom, name: 'Badgers') }
+
+      it 'returns all homerooms\', ordered alphabetically by name' do
+        expect(educator.allowed_homerooms_by_name).to eq [homeroom_103, homeroom_102, homeroom_101]
+      end
     end
   end
+
 end


### PR DESCRIPTION
## What's new?

+ Allow scoping educator access to student profiles and homeroom rosters by grade level
+ Allow scoping educator access to student profiles by student's SPED/Limited English status (i.e. SPED staff can only see profiles for students in SPED; ELL specialists can only see profiles for students with some kind of limited english proficiency status)

+ New permissions system has roughly four tiers:
  1. Schoolwide access
  2. Grade-level access to multiple grades (can be restricted by student's SPED / ELL status)
  3. Homeroom-level access (which gives access to one grade level)
  4. No access

## What's TODO?
+ Not all queries are ready for multi-school tenancy yet

+ Code in the concept of district-wide access: right now principals and district admins have the same permissions because there's only one school's worth of data