### PR TITLE
Validate educator LASIDs

### DIFF
--- a/app/models/educator.rb
+++ b/app/models/educator.rb
@@ -15,6 +15,7 @@ class Educator < ActiveRecord::Base
   has_many    :student_notes
 
   validates :email, presence: true, uniqueness: true
+  validates :local_id, presence: true, uniqueness: true
 
   def default_homeroom
     raise Exceptions::NoHomerooms if Homeroom.count == 0    # <= We can't show any homerooms if there are none

--- a/spec/factories/educators.rb
+++ b/spec/factories/educators.rb
@@ -1,10 +1,12 @@
 FactoryGirl.define do
 
   sequence(:email) { |n| "superteacher#{n}@somerville.edu" }
+  sequence(:staff_local_id) { |n| "000#{n}" }
 
   factory :educator do
     password "PairShareCompare"
     email { FactoryGirl.generate(:email) }
+    local_id { FactoryGirl.generate(:staff_local_id) }
 
     trait :admin do
       admin true
@@ -13,6 +15,14 @@ FactoryGirl.define do
 
     trait :local_id_200 do
       local_id '200'
+    end
+
+    trait :without_local_id do
+      local_id nil
+    end
+
+    trait :without_email do
+      email nil
     end
 
     factory :educator_with_homeroom do

--- a/spec/models/educator_spec.rb
+++ b/spec/models/educator_spec.rb
@@ -2,6 +2,22 @@ require 'rails_helper'
 
 RSpec.describe Educator do
 
+  describe '#local_id' do
+    context 'no local id' do
+      it 'is invalid' do
+        expect(FactoryGirl.build(:educator, :without_local_id)).to be_invalid
+      end
+    end
+  end
+
+  describe '#local_email' do
+    context 'no email' do
+      it 'is invalid' do
+        expect(FactoryGirl.build(:educator, :without_email)).to be_invalid
+      end
+    end
+  end
+
   describe '#default_homeroom' do
 
     context 'no homerooms' do


### PR DESCRIPTION
## Notes

+ When an unnamed developer (me) rolls educator records by hand and doesn't add the LASID (district-assigned local ID), that screws with the data flow later on

+ When the stream of educators coming in from X2 includes an educator that has been hand-rolled, it will need to match up to the educator by LASID

+ Otherwise it will throw `ActiveRecord::RecordInvalid` on the non-unique email value