### PR TITLE
Smarter page defaults and permissions for educators

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -21,7 +21,7 @@ class ApplicationController < ActionController::Base
 
   # Return the homepage path, depending on the educator's role
   def homepage_path_for_role(educator)
-    if educator.schoolwide_access?
+    if educator.schoolwide_access? || educator.has_access_to_grade_levels?
       school_url(educator.default_school)
     else
       default_homeroom_path(educator)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -21,8 +21,8 @@ class ApplicationController < ActionController::Base
 
   # Return the homepage path, depending on the educator's role
   def homepage_path_for_role(educator)
-    if educator.admin?
-      school_url(educator.default_school_for_admin)
+    if educator.schoolwide_access?
+      school_url(educator.default_school)
     else
       default_homeroom_path(educator)
     end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -28,6 +28,10 @@ class ApplicationController < ActionController::Base
     end
   end
 
+  def homepage_path_for_current_educator
+    homepage_path_for_role(current_educator)
+  end
+
   def default_homeroom_path(educator)
     homeroom_path(educator.default_homeroom)
   rescue Exceptions::NoAssignedHomeroom   # Thrown by educator without default homeroom

--- a/app/controllers/schools_controller.rb
+++ b/app/controllers/schools_controller.rb
@@ -1,6 +1,7 @@
 class SchoolsController < ApplicationController
 
-  before_action :authenticate_admin!      # Defined in ApplicationController.
+  before_action :authenticate_educator!,
+                :authorize
 
   def show
     @serialized_data = {
@@ -17,4 +18,12 @@ class SchoolsController < ApplicationController
       intervention_types: InterventionType.all
     }
   end
+
+  private
+
+  def authorize
+    redirect_to(homepage_path_for_current_educator) unless current_educator.schoolwide_access? ||
+                                                           current_educator.has_access_to_grade_levels?
+  end
+
 end

--- a/app/controllers/schools_controller.rb
+++ b/app/controllers/schools_controller.rb
@@ -1,6 +1,7 @@
 class SchoolsController < ApplicationController
 
   before_action :authenticate_educator!,
+                :assign_school,
                 :authorize
 
   def show
@@ -24,6 +25,10 @@ class SchoolsController < ApplicationController
   def authorize
     redirect_to(homepage_path_for_current_educator) unless current_educator.schoolwide_access? ||
                                                            current_educator.has_access_to_grade_levels?
+  end
+
+  def assign_school
+    @school = School.friendly.find(params[:id])
   end
 
 end

--- a/app/controllers/schools_controller.rb
+++ b/app/controllers/schools_controller.rb
@@ -4,6 +4,9 @@ class SchoolsController < ApplicationController
                 :assign_school,
                 :authorize
 
+  before_action :assign_students_for_show_page,     only: [:show]
+  before_action :assign_students_for_star_reading,  only: [:star_reading]
+
   def show
     @serialized_data = {
       students: SchoolStudentPresenter.from_students.map(&:as_json),
@@ -29,6 +32,14 @@ class SchoolsController < ApplicationController
 
   def assign_school
     @school = School.friendly.find(params[:id])
+  end
+
+  def assign_students_for_show_page
+    @students = current_educator.students_for_school_overview
+  end
+
+  def assign_students_for_star_reading
+    @students = current_educator.students_for_school_overview(:student_assessments)
   end
 
 end

--- a/app/controllers/schools_controller.rb
+++ b/app/controllers/schools_controller.rb
@@ -36,6 +36,11 @@ class SchoolsController < ApplicationController
   def authorize
     redirect_to(homepage_path_for_current_educator) unless current_educator.schoolwide_access? ||
                                                            current_educator.has_access_to_grade_levels?
+
+    if current_educator.has_access_to_grade_levels?
+      grade_message = " Showing students in grades #{current_educator.grade_level_access.to_sentence}."
+      flash[:notice] << grade_message if flash[:notice]
+    end
   end
 
   def assign_school

--- a/app/controllers/schools_controller.rb
+++ b/app/controllers/schools_controller.rb
@@ -8,16 +8,24 @@ class SchoolsController < ApplicationController
   before_action :assign_students_for_star_reading,  only: [:star_reading]
 
   def show
+    @serialized_students = @students.map do |student|
+      SchoolStudentPresenter.new(student).as_json
+    end
+
     @serialized_data = {
-      students: SchoolStudentPresenter.from_students.map(&:as_json),
+      students: @serialized_students,
       current_educator: current_educator,
       intervention_types: InterventionType.all
     }
   end
 
   def star_reading
+    @serialized_students = @students.map do |student|
+      SchoolStudentPresenter.new(student).as_json_with_star_reading
+    end
+
     @serialized_data = {
-      students_with_star_reading: SchoolStudentPresenter.from_students(:student_assessments).map(&:as_json_with_star_reading),
+      students_with_star_reading: @serialized_students,
       current_educator: current_educator,
       intervention_types: InterventionType.all
     }

--- a/app/models/educator.rb
+++ b/app/models/educator.rb
@@ -28,7 +28,7 @@ class Educator < ActiveRecord::Base
             .includes(eager_loads)
     elsif has_access_to_grade_levels?
       school.students
-            .where(grade: current_educator.grade_level_access)
+            .where(grade: grade_level_access)
             .includes(eager_loads)
     end
   end

--- a/app/models/educator.rb
+++ b/app/models/educator.rb
@@ -27,6 +27,10 @@ class Educator < ActiveRecord::Base
     school || School.first
   end
 
+  def has_access_to_grade_levels?
+    grade_level_access.present? && grade_level_access.size > 0
+  end
+
   def allowed_homerooms
     # Educator can visit roster view for these homerooms
     # For non-admins, all homerooms at their homeroom's grade level

--- a/app/models/educator.rb
+++ b/app/models/educator.rb
@@ -23,7 +23,7 @@ class Educator < ActiveRecord::Base
     raise Exceptions::NoAssignedHomeroom                    # <= Logged-in educator has no assigned homeroom
   end
 
-  def default_school_for_admin
+  def default_school
     school || School.first
   end
 

--- a/app/models/educator.rb
+++ b/app/models/educator.rb
@@ -18,7 +18,7 @@ class Educator < ActiveRecord::Base
   validates :local_id, presence: true, uniqueness: true
 
   def students_for_school_overview(*additional_includes)
-    return unless school.present?
+    return [] unless school.present?
 
     default_eager_loads = [ :interventions, :student_risk_level, :homeroom, :student_school_years ]
     eager_loads = default_eager_loads + additional_includes

--- a/app/presenters/school_student_presenter.rb
+++ b/app/presenters/school_student_presenter.rb
@@ -1,12 +1,4 @@
 class SchoolStudentPresenter < Struct.new(:student)
-  def self.from_students(*additional_includes)
-    Student.all.includes([
-      :interventions,
-      :student_risk_level,
-      :homeroom,
-      :student_school_years
-    ] + additional_includes).map { |s| new(s) }
-  end
 
   def as_json
     student.as_json.merge(

--- a/spec/controllers/homerooms_controller_spec.rb
+++ b/spec/controllers/homerooms_controller_spec.rb
@@ -124,12 +124,13 @@ describe HomeroomsController, :type => :controller do
           end
 
           context 'educator does not have appropriate grade level access' do
-            let(:educator) { FactoryGirl.create(:educator, grade_level_access: ['3'] )}
+            let(:school) { FactoryGirl.create(:school) }
+            let(:educator) { FactoryGirl.create(:educator, grade_level_access: ['3'], school: school )}
             let(:homeroom) { FactoryGirl.create(:grade_5_homeroom) }
 
             it 'redirects' do
               make_request(homeroom.slug)
-              expect(response).to redirect_to(no_homeroom_url)
+              expect(response).to redirect_to(school_path(school))
             end
           end
 

--- a/spec/controllers/homerooms_controller_spec.rb
+++ b/spec/controllers/homerooms_controller_spec.rb
@@ -123,7 +123,7 @@ describe HomeroomsController, :type => :controller do
             end
           end
 
-          context 'educator does not have appropriate grade level access' do
+          context 'educator does not have correct grade level access, but has access to a different grade' do
             let(:school) { FactoryGirl.create(:school) }
             let(:educator) { FactoryGirl.create(:educator, grade_level_access: ['3'], school: school )}
             let(:homeroom) { FactoryGirl.create(:grade_5_homeroom) }

--- a/spec/controllers/schools_controller_spec.rb
+++ b/spec/controllers/schools_controller_spec.rb
@@ -12,10 +12,12 @@ describe SchoolsController, :type => :controller do
     let!(:school) { FactoryGirl.create(:healey) }
 
     context 'educator is not an admin' do
-      let!(:educator) { FactoryGirl.create(:educator) }
-      it 'redirects to sign in page' do
+      let!(:educator) { FactoryGirl.create(:educator_with_homeroom) }
+      let!(:homeroom) { educator.homeroom }
+
+      it 'redirects to homeroom page' do
         make_request('hea')
-        expect(response).to redirect_to(new_educator_session_path)
+        expect(response).to redirect_to(homeroom_path(homeroom))
       end
     end
 

--- a/spec/controllers/schools_controller_spec.rb
+++ b/spec/controllers/schools_controller_spec.rb
@@ -8,27 +8,68 @@ describe SchoolsController, :type => :controller do
       get :show, id: school_id
     end
 
-    before { sign_in(educator) }
-    let!(:school) { FactoryGirl.create(:healey) }
-
-    context 'educator is not an admin' do
+    context 'educator is not an admin but does have a homeroom' do
+      let!(:school) { FactoryGirl.create(:healey) }
       let!(:educator) { FactoryGirl.create(:educator_with_homeroom) }
       let!(:homeroom) { educator.homeroom }
 
       it 'redirects to homeroom page' do
+        sign_in(educator)
         make_request('hea')
+
         expect(response).to redirect_to(homeroom_path(homeroom))
       end
     end
 
-    context 'educator is an admin' do
-      let!(:educator) { FactoryGirl.create(:educator, :admin) }
-      it 'is successful' do
+    context 'educator is an admin with schoolwide access' do
+      let!(:school) { FactoryGirl.create(:healey) }
+      let!(:educator) { FactoryGirl.create(:educator, :admin, school: school) }
+      let!(:include_me) { FactoryGirl.create(:student, :registered_last_year, school: school) }
+      let!(:include_me_too) { FactoryGirl.create(:student, :registered_last_year, school: school) }
+      let!(:include_me_not) { FactoryGirl.create(:student, :registered_last_year ) }
+
+      before { school.reload }
+      before { Student.update_student_school_years }
+
+      let(:serialized_data) { assigns(:serialized_data) }
+
+      it 'is successful and assigns the correct students' do
+        sign_in(educator)
         make_request('hea')
+
         expect(response).to be_success
-        expect(assigns(:serialized_data)).to include :students, :intervention_types
+
+        expect(assigns(:students)).to include include_me
+        expect(assigns(:students)).to include include_me_too
+        expect(assigns(:students)).not_to include include_me_not
       end
     end
+
+    context 'educator has grade-level access' do
+      let!(:school) { FactoryGirl.create(:healey) }
+      let!(:educator) { FactoryGirl.create(:educator, school: school, grade_level_access: ['4']) }
+
+      let!(:include_me) { FactoryGirl.create(:student, :registered_last_year, grade: '4', school: school) }
+      let!(:include_me_too) { FactoryGirl.create(:student, :registered_last_year, grade: '4', school: school) }
+      let!(:include_me_not) { FactoryGirl.create(:student, :registered_last_year, grade: '5', school: school) }
+
+      before { school.reload }
+      before { Student.update_student_school_years }
+
+      let(:serialized_data) { assigns(:serialized_data) }
+
+      it 'is successful and assigns the correct students' do
+        sign_in(educator)
+        make_request('hea')
+
+        expect(response).to be_success
+
+        expect(assigns(:students)).to include include_me
+        expect(assigns(:students)).to include include_me_too
+        expect(assigns(:students)).not_to include include_me_not
+      end
+    end
+
   end
 
 end

--- a/spec/models/educator_spec.rb
+++ b/spec/models/educator_spec.rb
@@ -18,6 +18,36 @@ RSpec.describe Educator do
     end
   end
 
+  describe '#students_for_school_overview' do
+    let!(:school) { FactoryGirl.create(:school) }
+
+    context 'schoolwide_access' do
+      let(:educator) { FactoryGirl.create(:educator, schoolwide_access: true, school: school) }
+      let!(:include_me) { FactoryGirl.create(:student, school: school) }
+      let!(:include_me_too) { FactoryGirl.create(:student, school: school) }
+      let!(:include_me_not) { FactoryGirl.create(:student) }
+
+      let(:students_for_school_overview) { educator.students_for_school_overview }
+
+      it 'returns all students in the school' do
+        expect(students_for_school_overview).to include include_me
+        expect(students_for_school_overview).to include include_me_too
+      end
+    end
+
+    context 'has_access_to_grade_levels' do
+      let(:educator) { FactoryGirl.create(:educator, grade_level_access: ['2'], school: school) }
+      let!(:include_me) { FactoryGirl.create(:student, school: school, grade: '2') }
+      let!(:include_me_not) { FactoryGirl.create(:student, school: school, grade: '1') }
+      let!(:include_me_not) { FactoryGirl.create(:student, grade: '2') }
+
+      it 'returns students at the appropriate grade levels' do
+        expect(educator.students_for_school_overview).to include include_me
+      end
+    end
+
+  end
+
   describe '#default_homeroom' do
 
     context 'no homerooms' do


### PR DESCRIPTION
## What's new?

+ Educators with access beyond a single homeroom + grade level root to school overview page

+ Their version of the school overview page includes students only within permitted grade levels

+ School overview page now takes a specific collection of students instead of all of 'em