### PR TITLE
Don't set schoolwide access via X2

### DIFF
--- a/app/importers/educator_row.rb
+++ b/app/importers/educator_row.rb
@@ -12,7 +12,6 @@ class EducatorRow < Struct.new(:row, :school_ids_dictionary)
       full_name: row[:full_name],
       staff_type: row[:staff_type],
       admin: is_admin?,
-      schoolwide_access: is_admin?,
       email: row[:login_name] + '@k12.somerville.ma.us',
       school_id: school_rails_id
     )

--- a/spec/importers/educators_importer_spec.rb
+++ b/spec/importers/educators_importer_spec.rb
@@ -133,7 +133,6 @@ RSpec.describe EducatorsImporter do
             described_class.new.import_row(row)
             educator = Educator.last
             expect(educator.admin).to eq(true)
-            expect(educator.schoolwide_access).to eq(true)
           end
         end
 


### PR DESCRIPTION
## Notes

+ X2 knows about admin status, and all admins have schoolwide access
+ But not all those with schoolwide access are admins!
+ Specialists who work across the entire school need schoolwide access to
+ And their roles are being set with a seed task, not via the X2 data link